### PR TITLE
feat: add cache listing endpoint

### DIFF
--- a/src/api/download.rs
+++ b/src/api/download.rs
@@ -6,7 +6,6 @@ use std::time::Duration;
 
 use crate::error::{ApiError, Result};
 use crate::http::AppState;
-use crate::storage::BlobStore;
 
 // GET /download/{random}/{filename}
 // We treat {random} as an opaque object key prefix (already known/stored in DB), and {filename} ignored for routing convenience

--- a/src/api/twirp.rs
+++ b/src/api/twirp.rs
@@ -4,12 +4,9 @@ use base64::engine::general_purpose;
 use uuid::Uuid;
 
 use super::types::*;
+use crate::error::{ApiError, Result};
 use crate::http::AppState;
 use crate::meta;
-use crate::{
-    error::{ApiError, Result},
-    storage::BlobStore,
-};
 
 // POST /twirp/.../CreateCacheEntry
 pub async fn create_cache_entry(

--- a/src/api/upload.rs
+++ b/src/api/upload.rs
@@ -4,6 +4,9 @@ use axum::{
     extract::{Path, Query, State},
 };
 use base64::{Engine as _, engine::general_purpose};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
 use uuid::Uuid;
 
 use crate::http::AppState;
@@ -13,6 +16,122 @@ use crate::{
     storage::BlobStore,
     storage::s3::S3Store,
 };
+
+const MAX_CACHE_KEY_LENGTH: usize = 512;
+
+#[derive(Debug, Deserialize)]
+pub struct ListCachesQuery {
+    key: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ListCachesResponse {
+    total_count: usize,
+    artifact_caches: Vec<ArtifactCacheSummary>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArtifactCacheSummary {
+    cache_id: Uuid,
+    scope: String,
+    cache_key: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    cache_version: Option<String>,
+    creation_time: DateTime<Utc>,
+    last_access_time: DateTime<Utc>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    archive_location: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    compressed_size: Option<i64>,
+}
+
+#[derive(Debug, Clone)]
+struct CacheListRow {
+    id: Uuid,
+    scope: String,
+    key: String,
+    size_bytes: i64,
+    storage_key: String,
+    created_at: DateTime<Utc>,
+    last_access_at: DateTime<Utc>,
+}
+
+async fn build_list_response(
+    entries: Vec<CacheListRow>,
+    store: &(dyn BlobStore),
+    enable_direct: bool,
+) -> Result<ListCachesResponse> {
+    let mut artifact_caches = Vec::with_capacity(entries.len());
+    for entry in entries {
+        let archive_location = if enable_direct {
+            store
+                .presign_get(&entry.storage_key, Duration::from_secs(3600))
+                .await
+                .map_err(|e| ApiError::S3(format!("{e}")))?
+                .map(|p| p.url.to_string())
+        } else {
+            None
+        };
+
+        artifact_caches.push(ArtifactCacheSummary {
+            cache_id: entry.id,
+            scope: entry.scope,
+            cache_key: entry.key,
+            cache_version: None,
+            creation_time: entry.created_at,
+            last_access_time: entry.last_access_at,
+            archive_location,
+            compressed_size: (entry.size_bytes > 0).then_some(entry.size_bytes),
+        });
+    }
+
+    Ok(ListCachesResponse {
+        total_count: artifact_caches.len(),
+        artifact_caches,
+    })
+}
+
+fn extract_list_key(key: Option<String>) -> Result<String> {
+    let raw = key
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+        .ok_or_else(|| ApiError::BadRequest("query parameter 'key' is required".into()))?;
+    if raw.len() > MAX_CACHE_KEY_LENGTH {
+        return Err(ApiError::BadRequest("key exceeds maximum length".into()));
+    }
+    if raw.chars().any(|c| c.is_control()) {
+        return Err(ApiError::BadRequest(
+            "key contains invalid characters".into(),
+        ));
+    }
+    Ok(raw)
+}
+
+// ====== actions/cache: GET /_apis/artifactcache/caches?key=my-key ======
+pub async fn list_caches(
+    State(st): State<AppState>,
+    Query(query): Query<ListCachesQuery>,
+) -> Result<Json<ListCachesResponse>> {
+    let key = extract_list_key(query.key)?;
+
+    let entries = sqlx::query_as!(
+        CacheListRow,
+        r#"
+            SELECT id, scope, key, size_bytes, storage_key, created_at, last_access_at
+            FROM cache_entries
+            WHERE key = $1
+            ORDER BY created_at DESC
+        "#,
+        key
+    )
+    .fetch_all(&st.pool)
+    .await?;
+
+    let body = build_list_response(entries, st.store.as_ref(), st.enable_direct).await?;
+    Ok(Json(body))
+}
 
 // ====== actions/cache: GET /_apis/artifactcache/cache?keys=k1,k2&version=sha ======
 pub async fn get_cache_entry(
@@ -123,4 +242,132 @@ pub async fn commit_cache(
         .await?;
     }
     Ok(StatusCode::CREATED)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::{BlobStore, PresignedUrl};
+    use async_trait::async_trait;
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+    use url::Url;
+
+    #[derive(Clone, Default)]
+    struct DummyStore {
+        url: Option<String>,
+        calls: Arc<AtomicUsize>,
+    }
+
+    impl DummyStore {
+        fn with_url(url: Option<&str>) -> Self {
+            Self {
+                url: url.map(|u| u.to_string()),
+                calls: Arc::new(AtomicUsize::new(0)),
+            }
+        }
+
+        fn call_count(&self) -> usize {
+            self.calls.load(Ordering::SeqCst)
+        }
+    }
+
+    #[async_trait]
+    impl BlobStore for DummyStore {
+        async fn create_multipart(&self, _key: &str) -> anyhow::Result<String> {
+            unimplemented!("not required for tests")
+        }
+
+        async fn upload_part(
+            &self,
+            _key: &str,
+            _upload_id: &str,
+            _part_number: i32,
+            _body: aws_sdk_s3::primitives::ByteStream,
+        ) -> anyhow::Result<String> {
+            unimplemented!("not required for tests")
+        }
+
+        async fn complete_multipart(
+            &self,
+            _key: &str,
+            _upload_id: &str,
+            _parts: Vec<(i32, String)>,
+        ) -> anyhow::Result<()> {
+            unimplemented!("not required for tests")
+        }
+
+        async fn presign_get(
+            &self,
+            _key: &str,
+            _ttl: Duration,
+        ) -> anyhow::Result<Option<PresignedUrl>> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(self.url.as_ref().map(|u| PresignedUrl {
+                url: Url::parse(u).unwrap(),
+            }))
+        }
+    }
+
+    fn sample_row() -> CacheListRow {
+        CacheListRow {
+            id: Uuid::new_v4(),
+            scope: "refs/heads/main".into(),
+            key: "demo".into(),
+            size_bytes: 42,
+            storage_key: "storage/demo".into(),
+            created_at: Utc::now(),
+            last_access_at: Utc::now(),
+        }
+    }
+
+    #[tokio::test]
+    async fn list_caches_builds_success_response() {
+        let store = DummyStore::with_url(Some("https://example.com/archive"));
+        let rows = vec![sample_row()];
+        let response = build_list_response(rows.clone(), &store, true)
+            .await
+            .expect("response");
+
+        assert_eq!(response.total_count, 1);
+        assert_eq!(store.call_count(), 1);
+        let cache = response.artifact_caches.first().expect("cache entry");
+        assert_eq!(cache.cache_key, rows[0].key);
+        assert_eq!(
+            cache.archive_location.as_deref(),
+            Some("https://example.com/archive")
+        );
+        assert_eq!(cache.compressed_size, Some(42));
+    }
+
+    #[tokio::test]
+    async fn list_caches_handles_empty_result() {
+        let store = DummyStore::with_url(Some("https://example.com/archive"));
+        let response = build_list_response(Vec::new(), &store, true)
+            .await
+            .expect("response");
+
+        assert_eq!(response.total_count, 0);
+        assert!(response.artifact_caches.is_empty());
+        assert_eq!(store.call_count(), 0);
+    }
+
+    #[test]
+    fn list_caches_rejects_invalid_key() {
+        let err = extract_list_key(None).expect_err("missing key should error");
+        assert!(matches!(err, ApiError::BadRequest(_)));
+
+        let err = extract_list_key(Some("   ".into())).expect_err("blank key should error");
+        assert!(matches!(err, ApiError::BadRequest(_)));
+
+        let err = extract_list_key(Some("a".repeat(MAX_CACHE_KEY_LENGTH + 1)))
+            .expect_err("long key should error");
+        assert!(matches!(err, ApiError::BadRequest(_)));
+
+        let err =
+            extract_list_key(Some("bad\u{0007}".into())).expect_err("control chars should error");
+        assert!(matches!(err, ApiError::BadRequest(_)));
+    }
 }

--- a/src/api/upload_compat.rs
+++ b/src/api/upload_compat.rs
@@ -6,7 +6,6 @@ use crate::http::AppState;
 use crate::meta;
 use crate::{
     error::{ApiError, Result},
-    storage::BlobStore,
     storage::s3::S3Store,
 };
 


### PR DESCRIPTION
## Summary
- add a GET handler for `/_apis/artifactcache/caches` that validates the cache key, queries Postgres, and returns the expected schema
- share the blob store via `Arc` in the application state and register the new GET route alongside the existing POST handler
- cover the new endpoint with unit tests for success, empty responses, and validation errors

## Testing
- cargo fmt --all
- cargo clippy --fix --allow-dirty --allow-staged --all-targets --all-features
- cargo test --all-targets --all-features

------
https://chatgpt.com/codex/tasks/task_e_68d1257591288333b015a306ce034240