### PR TITLE
fix: bind server on ipv6 unspecified address

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ mod storage;
 
 use axum::Router;
 use sqlx::postgres::PgPoolOptions;
-use std::net::SocketAddr;
+use std::net::{IpAddr, Ipv6Addr, SocketAddr};
 use std::sync::Arc;
 use tower::limit::ConcurrencyLimitLayer;
 
@@ -43,7 +43,7 @@ async fn main() -> anyhow::Result<()> {
     let app: Router =
         build_router(pool, store, &cfg).layer(ConcurrencyLimitLayer::new(cfg.max_concurrency));
 
-    let addr: SocketAddr = ([0, 0, 0, 0], cfg.port).into();
+    let addr = SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), cfg.port);
     tracing::info!(%addr, "listening");
     axum::serve(tokio::net::TcpListener::bind(addr).await?, app).await?;
     Ok(())


### PR DESCRIPTION
## Summary
- bind the server to the IPv6 unspecified address while keeping the existing startup flow
- import the IPv6 address types needed for the new binding

## Testing
- cargo fmt
- cargo clippy --all-targets --all-features
- cargo test --all-targets --all-features

------
https://chatgpt.com/codex/tasks/task_e_68d142a31824833382b70b811c188a94