### PR TITLE
Refactor blob upload streaming to be backend-neutral

### DIFF
--- a/src/http.rs
+++ b/src/http.rs
@@ -207,7 +207,7 @@ mod tests {
             _key: &str,
             _upload_id: &str,
             _part_number: i32,
-            _body: aws_sdk_s3::primitives::ByteStream,
+            _body: crate::storage::BlobUploadPayload,
         ) -> anyhow::Result<String> {
             unimplemented!("not required for tests")
         }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,4 +1,6 @@
 use async_trait::async_trait;
+use bytes::Bytes;
+use futures::stream::BoxStream;
 use std::time::Duration;
 
 pub mod s3;
@@ -7,15 +9,26 @@ pub struct PresignedUrl {
     pub url: url::Url,
 }
 
+/// Stream of bytes representing a multipart upload part.
+///
+/// The stream yields the raw body of a single part and propagates failures via
+/// [`anyhow::Error`]. Implementations must consume the stream at most once and
+/// either upload the entire payload or report an error.
+pub type BlobUploadPayload = BoxStream<'static, anyhow::Result<Bytes>>;
+
 #[async_trait]
 pub trait BlobStore: Send + Sync + 'static {
     async fn create_multipart(&self, key: &str) -> anyhow::Result<String>; // returns upload_id
+    /// Upload a single multipart part from the provided stream.
+    ///
+    /// Implementations should exhaust the stream exactly once, uploading its
+    /// complete contents or failing with an error.
     async fn upload_part(
         &self,
         key: &str,
         upload_id: &str,
         part_number: i32,
-        body: aws_sdk_s3::primitives::ByteStream,
+        body: BlobUploadPayload,
     ) -> anyhow::Result<String>; // returns etag
 
     async fn complete_multipart(


### PR DESCRIPTION
## Summary
- introduce a backend-neutral `BlobUploadPayload` stream type and document the multipart contract
- adapt `S3Store` to convert the generic stream into an AWS `ByteStream`
- update API handlers, tests, and mocks to build and forward the neutral upload stream

## Testing
- cargo clippy --all-targets --all-features
- cargo test --all-targets --all-features

------
https://chatgpt.com/codex/tasks/task_e_68d171aa01b883338db4f9ef071d414e