### PR TITLE
feat: add Google Cloud Storage backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -663,6 +663,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "bon"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2529c31017402be841eb45892278a6c21a000c0a17643af326c73a73f83f0fb"
+dependencies = [
+ "bon-macros",
+ "rustversion",
+]
+
+[[package]]
+name = "bon-macros"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d82020dadcb845a345591863adb65d74fa8dc5c18a0b6d408470e13b7adc7005"
+dependencies = [
+ "darling",
+ "ident_case",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -679,6 +704,9 @@ name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bytes-utils"
@@ -716,6 +744,12 @@ name = "cfg-if"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -830,6 +864,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32c"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
+dependencies = [
+ "rustc_version",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -886,6 +929,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "der"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -913,6 +991,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d630bccd429a5bb5a64b5e94f693bfc48c9f8566418fda4c494cc94f911f87cc"
 dependencies = [
  "powerfmt",
+ "serde",
 ]
 
 [[package]]
@@ -949,6 +1028,12 @@ name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ecdsa"
@@ -1206,8 +1291,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1217,9 +1304,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasi 0.14.7+wasi-0.2.4",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1236,13 +1325,18 @@ dependencies = [
  "bytes",
  "chrono",
  "futures",
+ "google-cloud-auth",
+ "google-cloud-storage",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.7.0",
  "hyper-rustls 0.27.7",
  "hyper-util",
+ "percent-encoding",
  "pin-project-lite",
+ "rand 0.8.5",
+ "rsa",
  "serde",
  "serde_json",
  "sha2",
@@ -1271,6 +1365,211 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "google-cloud-auth"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62d8757f37377c6436b94c6efaf7f9c3c6e48a213bb0790f7a639a9ba0183764"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bon",
+ "google-cloud-gax",
+ "http 1.3.1",
+ "reqwest",
+ "rustc_version",
+ "rustls 0.23.32",
+ "rustls-pemfile 2.2.0",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "time",
+ "tokio",
+]
+
+[[package]]
+name = "google-cloud-gax"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6b1718e2a6965a7fbb282f23645e7adb8e0a012848258bbd6f580307b684f"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures",
+ "google-cloud-rpc",
+ "google-cloud-wkt",
+ "http 1.3.1",
+ "pin-project",
+ "rand 0.9.2",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "google-cloud-gax-internal"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c7ec794189133a50fd3901af3cd7faa37a0a6bb331e49e58df652a37f035552"
+dependencies = [
+ "bytes",
+ "google-cloud-auth",
+ "google-cloud-gax",
+ "google-cloud-rpc",
+ "google-cloud-wkt",
+ "http 1.3.1",
+ "http-body-util",
+ "percent-encoding",
+ "prost",
+ "prost-types",
+ "reqwest",
+ "rustc_version",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tonic",
+ "tonic-prost",
+]
+
+[[package]]
+name = "google-cloud-iam-v1"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8b738ec3a484b20c015a571cde5e9e54487b2c168f3c0a5ea5eb21fafe7d2f"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "google-cloud-gax",
+ "google-cloud-gax-internal",
+ "google-cloud-type",
+ "google-cloud-wkt",
+ "lazy_static",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "tracing",
+]
+
+[[package]]
+name = "google-cloud-longrunning"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b74b20ebcbc64828070c63ae19876a2863ad9e256827a6cb956023df352d360"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "google-cloud-gax",
+ "google-cloud-gax-internal",
+ "google-cloud-rpc",
+ "google-cloud-wkt",
+ "lazy_static",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "tracing",
+]
+
+[[package]]
+name = "google-cloud-lro"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9d7432f793f49c9d556da45995f39539dcecdc2361de113b05b0f7bbed73072"
+dependencies = [
+ "google-cloud-gax",
+ "google-cloud-longrunning",
+ "google-cloud-rpc",
+ "google-cloud-wkt",
+ "serde",
+ "tokio",
+]
+
+[[package]]
+name = "google-cloud-rpc"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eaa87d841e35c69efa61786e7e7462b4ebdb96df7be79775aeb698b4c0cc52e"
+dependencies = [
+ "bytes",
+ "google-cloud-wkt",
+ "serde",
+ "serde_json",
+ "serde_with",
+]
+
+[[package]]
+name = "google-cloud-storage"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86f3e65b299e1c09811769c3b0dfefb6aa00a96646034994ccdf7c500c73dc22"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "crc32c",
+ "futures",
+ "google-cloud-auth",
+ "google-cloud-gax",
+ "google-cloud-gax-internal",
+ "google-cloud-iam-v1",
+ "google-cloud-longrunning",
+ "google-cloud-lro",
+ "google-cloud-rpc",
+ "google-cloud-type",
+ "google-cloud-wkt",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "hyper 1.7.0",
+ "lazy_static",
+ "md5",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "prost-types",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "sha2",
+ "thiserror",
+ "tokio",
+ "tonic",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "google-cloud-type"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a7190c5c073b273d952e6a01913302ce54f050861ead96d607089d380afdd8a"
+dependencies = [
+ "bytes",
+ "google-cloud-wkt",
+ "serde",
+ "serde_json",
+ "serde_with",
+]
+
+[[package]]
+name = "google-cloud-wkt"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccfa292c272695eb966fe8b08c78cabb35e7775771a1c7f97b58f7dcb7bfb26"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror",
+ "time",
+ "url",
+]
+
+[[package]]
 name = "group"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1293,7 +1592,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap",
+ "indexmap 2.11.4",
  "slab",
  "tokio",
  "tokio-util",
@@ -1312,12 +1611,18 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.3.1",
- "indexmap",
+ "indexmap 2.11.4",
  "slab",
  "tokio",
  "tokio-util",
  "tracing",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -1530,6 +1835,20 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.3",
  "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper 1.7.0",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -1667,6 +1986,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1689,12 +2014,25 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1713,6 +2051,16 @@ name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
+name = "iri-string"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
+dependencies = [
+ "memchr",
+ "serde",
+]
 
 [[package]]
 name = "itertools"
@@ -1839,6 +2187,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1864,6 +2218,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "md5"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae960838283323069879657ca3de837e9f7bbb4c7bf6ea7f1b290d5e9476d2e0"
+
+[[package]]
 name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1874,6 +2234,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "minimal-lexical"
@@ -2056,6 +2426,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "pin-project"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2148,6 +2538,93 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7231bd9b3d3d33c86b58adbac74b5ec0ad9f496b19d22801d773636feaa95f3d"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9b4db3d6da204ed77bb26ba83b6122a73aeb2e87e25fbf7ad2e84c4ccbf8f72"
+dependencies = [
+ "prost",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls 0.23.32",
+ "socket2 0.6.0",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.3",
+ "lru-slab",
+ "rand 0.9.2",
+ "ring",
+ "rustc-hash",
+ "rustls 0.23.32",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2 0.6.0",
+ "tracing",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2231,6 +2708,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a0ae411dbe946a674d89546582cea4ba2bb8defac896622d6496f14c23ba5cf"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "regex"
 version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2264,6 +2761,48 @@ name = "regex-syntax"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
+
+[[package]]
+name = "reqwest"
+version = "0.12.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d429f34c8092b2d42c7c93cec323bb4adeb7c67698f70839adec842ec10c7ceb"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.7.0",
+ "hyper-rustls 0.27.7",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime_guess",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls 0.23.32",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls 0.26.3",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+ "webpki-roots",
+]
 
 [[package]]
 name = "rfc6979"
@@ -2304,6 +2843,7 @@ dependencies = [
  "pkcs1",
  "pkcs8 0.10.2",
  "rand_core 0.6.4",
+ "sha2",
  "signature 2.2.0",
  "spki 0.7.3",
  "subtle",
@@ -2363,7 +2903,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd3c25631629d034ce7cd9940adc9d45762d46de2b0f57193c4443b92c6d4d40"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki 0.103.6",
  "subtle",
@@ -2377,7 +2919,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
  "schannel",
  "security-framework 2.11.1",
 ]
@@ -2404,11 +2946,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -2453,6 +3005,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
 dependencies = [
  "windows-sys 0.61.0",
+]
+
+[[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82d20c4491bc164fa2f6c5d44565947a52ad80b9505d8e36f8d54c27c739fcd0"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -2591,6 +3167,38 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c522100790450cf78eeac1507263d0a350d4d5b30df0c8e1fe051a10c22b376e"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.11.4",
+ "schemars 0.9.0",
+ "schemars 1.0.4",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "327ada00f7d64abaac1e55a6911e90cf665aa051b9a561c7006c157f4633135e"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2755,7 +3363,7 @@ dependencies = [
  "futures-util",
  "hashbrown 0.15.5",
  "hashlink",
- "indexmap",
+ "indexmap 2.11.4",
  "log",
  "memchr",
  "once_cell",
@@ -2937,6 +3545,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2958,6 +3572,9 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -3019,6 +3636,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
 dependencies = [
  "deranged",
+ "itoa",
  "num-conv",
  "powerfmt",
  "serde",
@@ -3142,6 +3760,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb7613188ce9f7df5bfe185db26c5814347d110db17920415cf2fbcad85e7203"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.7.0",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "rustls-native-certs 0.8.1",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls 0.26.3",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66bd50ad6ce1252d87ef024b3d64fe4c3cf54a86fb9ef4c631fdd0ded7aeaa67"
+dependencies = [
+ "bytes",
+ "prost",
+ "tonic",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3149,13 +3805,33 @@ checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap 2.11.4",
  "pin-project-lite",
+ "slab",
  "sync_wrapper",
  "tokio",
  "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -3243,6 +3919,12 @@ name = "typenum"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+
+[[package]]
+name = "unicase"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-bidi"
@@ -3404,6 +4086,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0b221ff421256839509adbb55998214a70d829d3a28c69b4a6672e9d2a42f67"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3433,6 +4128,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "293c37f4efa430ca14db3721dfbe48d8c33308096bd44d80ebaa775ab71ba1cf"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbe734895e869dc429d78c4b433f8d17d95f8d05317440b4fad5ab2d33e596dc"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e8983c3ab33d6fb807cfcdad2491c4ea8cbc8ed839181c7dfd9c67c83e261b2"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,13 +14,18 @@ base64 = { version = "0.22" }
 bytes = { version = "1" }
 chrono = { version = "0.4", features = ["serde"] }
 futures = { version = "0.3.31" }
+google-cloud-auth = { version = "1" }
+google-cloud-storage = { version = "1" }
 http = { version = "1" }
 http-body = { version = "1" }
 http-body-util = { version = "0.1" }
 hyper = { version = "1", features = ["http1", "server"] }
 hyper-rustls = { version = "0.27.7", default-features = false, features = ["aws-lc-rs", "http1", "native-tokio", "tls12"] }
 hyper-util = { version = "0.1.6", features = ["client", "client-legacy", "http1", "tokio"] }
+percent-encoding = { version = "2" }
 pin-project-lite = { version = "0.2" }
+rand = { version = "0.8" }
+rsa = { version = "0.9", features = ["sha2"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1" }
 sha2 = { version = "0.10" }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,6 +13,8 @@ The server supports pluggable blob storage. Select the implementation via the
   * `S3_FORCE_PATH_STYLE` (defaults to `true`)
 * `fs` – persist cache archives on the local filesystem. This mode requires a
   dedicated root directory and supports optional POSIX permissions.
+* `gcs` – store cache archives in Google Cloud Storage. This mode requires a
+  dedicated bucket and service account credentials (see below).
 
 ## Filesystem store settings
 
@@ -28,3 +30,19 @@ When `BLOB_STORE=fs` the process reads additional options:
 
 When the filesystem backend is active, direct-download URLs are not generated;
 callers should stream downloads through the HTTP API instead.
+
+## Google Cloud Storage settings
+
+When `BLOB_STORE=gcs`, configure the following environment variables:
+
+* `GCS_BUCKET` – name of the bucket that should receive cache archives.
+* Authentication credentials. Provide either:
+  * `GCS_SERVICE_ACCOUNT_JSON` – inline JSON for a service account key.
+  * `GCS_SERVICE_ACCOUNT_PATH` – path to a file containing the service account
+    key JSON.
+* `GCS_ENDPOINT` – optional custom endpoint (for example an emulator). When
+  omitted the client uses `https://storage.googleapis.com`.
+
+The GCS backend composes multipart uploads from temporary objects inside the
+target bucket and automatically issues V4-signed download URLs when direct
+downloads are enabled.

--- a/src/http.rs
+++ b/src/http.rs
@@ -245,6 +245,7 @@ mod tests {
                 force_path_style: true,
             }),
             fs: None,
+            gcs: None,
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ use anyhow::Context;
 
 use crate::http::build_router;
 use config::{BlobStoreSelector, Config};
-use storage::{BlobStore, fs::FsStore, s3::S3Store};
+use storage::{BlobStore, fs::FsStore, gcs::GcsStore, s3::S3Store};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -52,6 +52,13 @@ async fn main() -> anyhow::Result<()> {
                 .as_ref()
                 .context("missing filesystem configuration for selected backend")?;
             Arc::new(FsStore::new(fs_cfg.root.clone(), fs_cfg.file_mode, fs_cfg.dir_mode).await?)
+        }
+        BlobStoreSelector::Gcs => {
+            let gcs_cfg = cfg
+                .gcs
+                .as_ref()
+                .context("missing GCS configuration for selected backend")?;
+            Arc::new(GcsStore::new(gcs_cfg.clone()).await?)
         }
     };
 

--- a/src/storage/gcs.rs
+++ b/src/storage/gcs.rs
@@ -1,0 +1,551 @@
+use std::io;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context, Result, anyhow, bail};
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use futures::StreamExt;
+use google_cloud_auth::credentials::Credentials;
+use google_cloud_auth::credentials::service_account;
+use google_cloud_storage::client::{Storage, StorageControl};
+use google_cloud_storage::model::{Object, compose_object_request::SourceObject};
+use google_cloud_storage::streaming_source::{Payload, SizeHint, StreamingSource};
+use percent_encoding::{AsciiSet, NON_ALPHANUMERIC, percent_encode};
+use rand::rngs::OsRng;
+use rsa::RsaPrivateKey;
+use rsa::pkcs1::DecodeRsaPrivateKey;
+use rsa::pkcs1v15::SigningKey;
+use rsa::pkcs8::DecodePrivateKey;
+use rsa::signature::{RandomizedSigner, SignatureEncoding};
+use sha2::{Digest, Sha256};
+use tokio::sync::Mutex;
+use url::Url;
+
+use crate::config::{GcsConfig, ServiceAccountKeyConfig};
+use crate::storage::{BlobStore, BlobUploadPayload, PresignedUrl};
+
+const UPLOAD_PREFIX: &str = ".gha-cache/uploads";
+const MAX_COMPOSE_COMPONENTS: usize = 32;
+
+const PATH_ENCODE_SET: &AsciiSet = &NON_ALPHANUMERIC
+    .remove(b'-')
+    .remove(b'_')
+    .remove(b'.')
+    .remove(b'~')
+    .remove(b'/');
+const QUERY_ENCODE_SET: &AsciiSet = &NON_ALPHANUMERIC
+    .remove(b'-')
+    .remove(b'_')
+    .remove(b'.')
+    .remove(b'~');
+
+fn make_part_object_name(upload_id: &str, part_number: i32) -> String {
+    format!(
+        "{UPLOAD_PREFIX}/{upload_id}/part-{part_number:05}",
+        upload_id = upload_id,
+        part_number = part_number
+    )
+}
+
+fn make_stage_object_name(upload_id: &str, stage: usize, index: usize) -> String {
+    format!(
+        "{UPLOAD_PREFIX}/{upload_id}/stage-{stage:04}-{index:04}",
+        upload_id = upload_id,
+        stage = stage,
+        index = index
+    )
+}
+
+#[derive(Debug, PartialEq)]
+enum ComposeAction {
+    Compose {
+        sources: Vec<String>,
+        destination: String,
+    },
+    Delete(String),
+}
+
+#[derive(Clone)]
+pub struct GcsStore {
+    storage: Storage,
+    control: StorageControl,
+    bucket_resource: String,
+    bucket_name: String,
+    base_url: Url,
+    signer: GcsSigner,
+}
+
+impl GcsStore {
+    pub async fn new(config: GcsConfig) -> Result<Self> {
+        let credentials = build_credentials(&config.credentials.raw_json)?;
+        let mut storage_builder = Storage::builder().with_credentials(credentials.clone());
+        let mut control_builder = StorageControl::builder().with_credentials(credentials.clone());
+        if let Some(endpoint) = &config.endpoint {
+            storage_builder = storage_builder.with_endpoint(endpoint.clone());
+            control_builder = control_builder.with_endpoint(endpoint.clone());
+        }
+        let storage = storage_builder.build().await?;
+        let control = control_builder.build().await?;
+
+        let base_url = if let Some(endpoint) = &config.endpoint {
+            Url::parse(endpoint).context("invalid GCS endpoint URL")?
+        } else {
+            Url::parse("https://storage.googleapis.com")?
+        };
+        if base_url.path() != "/" {
+            bail!("GCS endpoint URL must not include a path component");
+        }
+
+        let signer = GcsSigner::new(&config.credentials.service_account)?;
+
+        Ok(Self {
+            storage,
+            control,
+            bucket_resource: format!("projects/_/buckets/{}", config.bucket),
+            bucket_name: config.bucket,
+            base_url,
+            signer,
+        })
+    }
+
+    fn part_object_name(&self, upload_id: &str, part_number: i32) -> String {
+        make_part_object_name(upload_id, part_number)
+    }
+
+    async fn compose_into(&self, sources: &[String], destination: &str) -> Result<()> {
+        let dest = Object::new()
+            .set_bucket(self.bucket_resource.clone())
+            .set_name(destination.to_string());
+        let request = self
+            .control
+            .compose_object()
+            .set_destination(dest)
+            .set_source_objects(
+                sources
+                    .iter()
+                    .map(|name| SourceObject::new().set_name(name.clone())),
+            );
+        request.send().await?;
+        Ok(())
+    }
+
+    async fn delete_object(&self, name: &str) {
+        let _ = self
+            .control
+            .delete_object()
+            .set_bucket(self.bucket_resource.clone())
+            .set_object(name.to_string())
+            .send()
+            .await;
+    }
+
+    async fn compose_parts(&self, upload_id: &str, key: &str, sources: Vec<String>) -> Result<()> {
+        let actions = build_compose_plan(upload_id, key, sources)?;
+        for action in actions {
+            match action {
+                ComposeAction::Compose {
+                    sources,
+                    destination,
+                } => {
+                    self.compose_into(&sources, &destination).await?;
+                }
+                ComposeAction::Delete(name) => {
+                    self.delete_object(&name).await;
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+fn build_credentials(raw_json: &serde_json::Value) -> Result<Credentials> {
+    service_account::Builder::new(raw_json.clone())
+        .build()
+        .map_err(|e| e.into())
+}
+
+fn build_compose_plan(
+    upload_id: &str,
+    key: &str,
+    mut sources: Vec<String>,
+) -> Result<Vec<ComposeAction>> {
+    if sources.is_empty() {
+        bail!("multipart upload must include at least one part");
+    }
+    let mut actions = Vec::new();
+    let mut stage = 0usize;
+    while sources.len() > MAX_COMPOSE_COMPONENTS {
+        let mut next = Vec::with_capacity(sources.len().div_ceil(MAX_COMPOSE_COMPONENTS));
+        for (idx, chunk) in sources.chunks(MAX_COMPOSE_COMPONENTS).enumerate() {
+            if chunk.len() == 1 {
+                next.push(chunk[0].clone());
+                continue;
+            }
+            let temp_name = make_stage_object_name(upload_id, stage, idx);
+            actions.push(ComposeAction::Compose {
+                sources: chunk.to_vec(),
+                destination: temp_name.clone(),
+            });
+            for name in chunk {
+                actions.push(ComposeAction::Delete(name.clone()));
+            }
+            next.push(temp_name);
+        }
+        sources = next;
+        stage += 1;
+    }
+
+    actions.push(ComposeAction::Compose {
+        sources: sources.clone(),
+        destination: key.to_string(),
+    });
+    for name in sources {
+        actions.push(ComposeAction::Delete(name));
+    }
+    Ok(actions)
+}
+
+#[async_trait]
+impl BlobStore for GcsStore {
+    async fn create_multipart(&self, _key: &str) -> Result<String> {
+        Ok(uuid::Uuid::new_v4().to_string())
+    }
+
+    async fn upload_part(
+        &self,
+        _key: &str,
+        upload_id: &str,
+        part_number: i32,
+        body: BlobUploadPayload,
+    ) -> Result<String> {
+        let object_name = self.part_object_name(upload_id, part_number);
+        let payload: Payload<GcsStreamSource> = Payload::from_stream(GcsStreamSource::new(body));
+        let object = self
+            .storage
+            .write_object::<_, _, _, GcsStreamSource>(
+                self.bucket_resource.clone(),
+                object_name,
+                payload,
+            )
+            .send_buffered()
+            .await?;
+        if object.etag.is_empty() {
+            Ok(object.generation.to_string())
+        } else {
+            Ok(object.etag)
+        }
+    }
+
+    async fn complete_multipart(
+        &self,
+        key: &str,
+        upload_id: &str,
+        parts: Vec<(i32, String)>,
+    ) -> Result<()> {
+        let mut numbers: Vec<i32> = parts.into_iter().map(|(n, _)| n).collect();
+        if numbers.is_empty() {
+            bail!("multipart upload must include at least one part");
+        }
+        numbers.sort_unstable();
+        let names = numbers
+            .into_iter()
+            .map(|n| self.part_object_name(upload_id, n))
+            .collect();
+        self.compose_parts(upload_id, key, names).await
+    }
+
+    async fn presign_get(&self, key: &str, ttl: Duration) -> Result<Option<PresignedUrl>> {
+        let url = self
+            .signer
+            .sign(&self.base_url, &self.bucket_name, key, ttl)?;
+        Ok(Some(PresignedUrl { url }))
+    }
+}
+
+#[derive(Clone)]
+struct GcsSigner {
+    email: String,
+    private_key: Arc<RsaPrivateKey>,
+    clock: Arc<dyn Fn() -> DateTime<Utc> + Send + Sync>,
+}
+
+impl GcsSigner {
+    fn new(config: &ServiceAccountKeyConfig) -> Result<Self> {
+        Self::from_parts(config, Arc::new(Utc::now))
+    }
+
+    fn from_parts(
+        config: &ServiceAccountKeyConfig,
+        clock: Arc<dyn Fn() -> DateTime<Utc> + Send + Sync>,
+    ) -> Result<Self> {
+        let _ = &config.private_key_id;
+        let pem = config.private_key.replace("\\n", "\n");
+        let private_key = RsaPrivateKey::from_pkcs8_pem(&pem)
+            .or_else(|_| RsaPrivateKey::from_pkcs1_pem(&pem))
+            .map_err(|err| anyhow!("failed to parse service account private key: {err}"))?;
+        Ok(Self {
+            email: config.client_email.clone(),
+            private_key: Arc::new(private_key),
+            clock,
+        })
+    }
+
+    #[cfg(test)]
+    fn with_clock(
+        config: &ServiceAccountKeyConfig,
+        clock: Arc<dyn Fn() -> DateTime<Utc> + Send + Sync>,
+    ) -> Result<Self> {
+        Self::from_parts(config, clock)
+    }
+
+    fn sign(&self, base_url: &Url, bucket: &str, object: &str, ttl: Duration) -> Result<Url> {
+        let expires = ttl.as_secs();
+        if expires == 0 {
+            bail!("signed URL TTL must be at least one second");
+        }
+        let expires = expires.min(604800);
+
+        let host = base_url
+            .host_str()
+            .ok_or_else(|| anyhow!("GCS endpoint URL must include a host"))?;
+        let mut header_host = host.to_string();
+        if let Some(port) = base_url.port() {
+            let default_port = match base_url.scheme() {
+                "http" => 80,
+                "https" => 443,
+                _ => port,
+            };
+            if port != default_port {
+                header_host = format!("{host}:{port}");
+            }
+        }
+
+        let now = (self.clock)();
+        let timestamp = now.format("%Y%m%dT%H%M%SZ").to_string();
+        let date = now.format("%Y%m%d").to_string();
+        let scope = format!("{date}/auto/storage/goog4_request");
+        let credential = format!("{}/{scope}", self.email);
+
+        let canonical_uri = format!(
+            "/{}/{}",
+            percent_encode(bucket.as_bytes(), PATH_ENCODE_SET),
+            percent_encode(object.as_bytes(), PATH_ENCODE_SET)
+        );
+
+        let mut params = vec![
+            (
+                "X-Goog-Algorithm".to_string(),
+                "GOOG4-RSA-SHA256".to_string(),
+            ),
+            ("X-Goog-Credential".to_string(), credential.clone()),
+            ("X-Goog-Date".to_string(), timestamp.clone()),
+            ("X-Goog-Expires".to_string(), expires.to_string()),
+            ("X-Goog-SignedHeaders".to_string(), "host".to_string()),
+        ];
+        let canonical_query = encode_query(&params);
+
+        let canonical_headers = format!("host:{}\n", header_host);
+        let signed_headers = "host";
+        let canonical_request = format!(
+            "GET\n{canonical_uri}\n{canonical_query}\n{canonical_headers}\n{signed_headers}\nUNSIGNED-PAYLOAD"
+        );
+        let hashed = Sha256::digest(canonical_request.as_bytes());
+        let hashed_hex = to_hex(&hashed);
+
+        let string_to_sign = format!("GOOG4-RSA-SHA256\n{timestamp}\n{scope}\n{hashed_hex}");
+
+        let signing_key = SigningKey::<Sha256>::new((*self.private_key).clone());
+        let signature = signing_key
+            .sign_with_rng(&mut OsRng, string_to_sign.as_bytes())
+            .to_vec();
+        let signature_hex = to_hex(&signature);
+
+        params.push(("X-Goog-Signature".to_string(), signature_hex));
+        let query = encode_query(&params);
+        let final_url = format!(
+            "{}://{}{}?{}",
+            base_url.scheme(),
+            header_host,
+            canonical_uri,
+            query
+        );
+        Url::parse(&final_url).context("failed to build signed URL")
+    }
+}
+
+struct GcsStreamSource {
+    inner: Arc<Mutex<BlobUploadPayload>>,
+}
+
+impl GcsStreamSource {
+    fn new(inner: BlobUploadPayload) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(inner)),
+        }
+    }
+}
+
+impl StreamingSource for GcsStreamSource {
+    type Error = io::Error;
+
+    fn next(
+        &mut self,
+    ) -> impl std::future::Future<Output = Option<Result<bytes::Bytes, io::Error>>> + Send {
+        let inner = Arc::clone(&self.inner);
+        async move {
+            let mut guard = inner.lock().await;
+            match guard.next().await {
+                Some(Ok(bytes)) => Some(Ok(bytes)),
+                Some(Err(err)) => Some(Err(io::Error::other(err.to_string()))),
+                None => None,
+            }
+        }
+    }
+
+    fn size_hint(&self) -> impl std::future::Future<Output = Result<SizeHint, io::Error>> + Send {
+        let inner = Arc::clone(&self.inner);
+        async move {
+            let guard = inner.lock().await;
+            let (lower, upper) = guard.size_hint();
+            Ok(size_hint_from_bounds(lower, upper))
+        }
+    }
+}
+
+fn size_hint_from_bounds(lower: usize, upper: Option<usize>) -> SizeHint {
+    let mut hint = SizeHint::new();
+    hint.set_lower(lower as u64);
+    if let Some(upper) = upper {
+        hint.set_upper(upper as u64);
+    }
+    hint
+}
+
+fn encode_query(params: &[(String, String)]) -> String {
+    let mut encoded: Vec<String> = params
+        .iter()
+        .map(|(k, v)| {
+            format!(
+                "{}={}",
+                percent_encode(k.as_bytes(), QUERY_ENCODE_SET),
+                percent_encode(v.as_bytes(), QUERY_ENCODE_SET)
+            )
+        })
+        .collect();
+    encoded.sort();
+    encoded.join("&")
+}
+
+fn to_hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    const TEST_PRIVATE_KEY: &str = "-----BEGIN PRIVATE KEY-----\nMIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQC8TUWONZPa4/cv\nNtKsIYPzx4MD/xkOZZPjtZuIK9P2zoI77aAeD8df8Jx0kFkYQpgZDq+7S37FaNm9\n/sATTYrHs7j1kVwjajy7x+ulAhy0Wyu3g7zoOMtLvzEoAqUmYgUNLxAH+C+ArlX2\nWwviT0CMqcOHwHv6oANzdImWensJcSoxeE+EKKLhfoPdRRllLjvN7Q1c8Pd3ixgn\nm0ZhRGErhphGbwV5OgGjFUShfmIC9cubKTpqrxzVR+UQtqZ/hcOjxS8gzQpe+DNV\nM/7nD1DME0Des0DLOwDb4+4BzetHFhSIe7QB/Wnh1Wp1eYuyvLUz057HDAfwjI2h\nxrDe/HtfAgMBAAECggEADSv5Pe22Llfx9jCHOMPjag2+YWzaa4JkKkfi3aSgiswp\nRK3mRxQNe0LmftTgwUIEnQQaUNICx9ECIjiMEQ2Z3pxOHNy9LZEEjJIl2VYLfKY/\n/vH30zqzJdT1naSJuY9JESywmg4crItat1qTuzyV+auft4LvE+SrjnZMGuWYblwy\n+3iKgACsnfU9OcrnfXe6I66sVUeeqAjDsqW/vnN5Hdpo057yQlygRs6rIgCS5H68\nXaO+YsLQeaxY5/gJ4n3itGOCwV5sZZ+HLiVIx6cAg0S6rLMFQek0B23Jon+/mKsX\nB4HQgElQe3R2h3vwLvKjQ6dh+NQxhG6wShhMkSsxSQKBgQDvKfYLS4p1Pv/VxNVI\nSOCoy0MVi+7SBXsxXHNTvMig2GcA2QHSk2TXS6HI4TPJUFFOSlr1GTMhLgwZYDvP\nvkdINejOYxEA/ZCt98minaPnmwzNgc9nelmtarUo2fOQ/76+qLe8Z4eqYJCk5kLm\nHwiu2aLUcH6kxbaAR5tw/52SHQKBgQDJjrYSOwJmOT1yJ/2tiWzse/bJoy7cZ4pN\n6VK9CpHaDMBS3rTG3OK8llBmLVlrUBB1jRwAfgkL1sPs9CnzOTTPeaZx2rAnwZGx\nYwxYQEYLC3eNnz9uyojzD2TzyWIssCM21GHjkaWsecBoV8XrbGs2kLGe+VeXgzRZ\nJHP03mXKqwKBgCvH1aeZq33tC245ewWheabMlroyBITjxfpyPxZcH6n6E1j/YKsI\nmlQjHzmjqBQ5JLkdOWtWsppnUIWwrSJJZckdPUHStsEkqcB+9KVVEDUMmBpiofIC\nXro1J3aT91daybMjNYdCuH4C8VeOYz62/aLsajdTZIuLOe5frV/RGyotAoGAEUf2\nHlwG2aLgvM/m9SEKQMBkKWefVfBesE1n9aNZW/up5bEIiOBZZFfy7r/GoefMcXe2\nxegIeIZiaAeLLTpjZ8KDXdGlNtNm3XGjllF0b+/8wRy9QI+G7GgOfMRwcWpsqn/N\nIMjVDpOlxox4ALZb/uKrB/lS5D+wllAEzSLgUV8CgYBHjsa2qZUi8zkkSgbA2ueU\n0ClzugJc/sLJ7ePwNEATfIvGOq7ZGYmx/wd0ghy/FwUcA0sK2Tj5O/KvT6iX9m5s\n3o12N+x90tMTyXBJd5M6wDTZlOpiFcqovOOi2kVe4kb13IHgMFOfmN5wvCcL1qhd\nL9k+Zdlx7/HuONEsjRUn+w==\n-----END PRIVATE KEY-----\n";
+
+    fn sample_key() -> ServiceAccountKeyConfig {
+        ServiceAccountKeyConfig {
+            client_email: "test-sa@example.iam.gserviceaccount.com".into(),
+            private_key_id: "test-key".into(),
+            private_key: TEST_PRIVATE_KEY.into(),
+        }
+    }
+
+    #[test]
+    fn part_object_name_is_stable() {
+        assert_eq!(
+            make_part_object_name("upload", 7),
+            ".gha-cache/uploads/upload/part-00007"
+        );
+        assert_eq!(
+            make_part_object_name("upload", 12345),
+            ".gha-cache/uploads/upload/part-12345"
+        );
+    }
+
+    #[test]
+    fn compose_plan_for_single_part() {
+        let actions = build_compose_plan("upload", "final", vec!["part-a".into()]).unwrap();
+        assert_eq!(
+            actions,
+            vec![
+                ComposeAction::Compose {
+                    sources: vec!["part-a".into()],
+                    destination: "final".into(),
+                },
+                ComposeAction::Delete("part-a".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn compose_plan_chunks_large_uploads() {
+        let part_names: Vec<String> = (1..=65)
+            .map(|idx| make_part_object_name("upload", idx))
+            .collect();
+        let actions = build_compose_plan("upload", "final", part_names.clone()).unwrap();
+
+        let mut compose_destinations = Vec::new();
+        let mut deletes = HashSet::new();
+        for action in &actions {
+            match action {
+                ComposeAction::Compose {
+                    sources,
+                    destination,
+                } => {
+                    assert!(sources.len() <= MAX_COMPOSE_COMPONENTS);
+                    compose_destinations.push((destination.clone(), sources.clone()));
+                }
+                ComposeAction::Delete(name) => {
+                    deletes.insert(name.clone());
+                }
+            }
+        }
+
+        assert_eq!(compose_destinations.len(), 3);
+        let final_compose = compose_destinations
+            .iter()
+            .find(|(dest, _)| dest == "final")
+            .expect("final compose step present");
+        assert_eq!(final_compose.1.len(), 3);
+        for name in final_compose.1.iter() {
+            if name.ends_with("stage-0000-0000") || name.ends_with("stage-0000-0001") {
+                assert!(deletes.contains(name));
+            }
+        }
+        for name in &part_names {
+            assert!(deletes.contains(name), "missing delete for {name}");
+        }
+    }
+
+    #[test]
+    fn signer_generates_expected_url() -> Result<()> {
+        let clock = Arc::new(|| {
+            DateTime::parse_from_rfc3339("2024-01-02T03:04:05Z")
+                .unwrap()
+                .with_timezone(&Utc)
+        });
+        let signer = GcsSigner::with_clock(&sample_key(), clock)?;
+        let base = Url::parse("https://storage.googleapis.com")?;
+        let url = signer.sign(
+            &base,
+            "example-bucket",
+            "path/to/object.tar",
+            Duration::from_secs(600),
+        )?;
+
+        assert_eq!(url.scheme(), "https");
+        assert_eq!(url.host_str(), Some("storage.googleapis.com"));
+        assert_eq!(url.path(), "/example-bucket/path/to/object.tar");
+        assert_eq!(
+            url.to_string(),
+            "https://storage.googleapis.com/example-bucket/path/to/object.tar?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=test-sa%40example.iam.gserviceaccount.com%2F20240102%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20240102T030405Z&X-Goog-Expires=600&X-Goog-Signature=2429d09964a6ffcaa1d1a615c516ed63ba360159f3eed90370e2d7ac76352b985c0a6594beab49ff9b027354414fa4e642c8c420135b60a5496e437be98e60e617528117145e2ab5da875e4c40f8042d0de409ca6241103374711ecf8185027554bdf077d657774f979b1fe4a4f91ec62d2a3486f76914912eecf3228663a0d76b33fb94e2b2678bc889bff1746c33acc73d5180dc51961bf43a4c1c82c2c2860a2a026c0dc723ca21ef63360d19e196bc25e67d93a257ea96ab7142e880f2a2dd2ced99d67d8d7b2c2e581569e216a4c0ff3665ae7553379b8ec3384b793f9b604ac54e07e3b1d7152704c73392648cb1f8c8f9a3111748882548ab9effabda&X-Goog-SignedHeaders=host"
+        );
+        Ok(())
+    }
+}

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -4,6 +4,7 @@ use futures::stream::BoxStream;
 use std::time::Duration;
 
 pub mod fs;
+pub mod gcs;
 pub mod s3;
 
 pub struct PresignedUrl {


### PR DESCRIPTION
## Summary
- add a Google Cloud Storage blob store implementation with multipart compose planning and V4 signing helpers
- extend configuration and startup logic to select the GCS backend and document the required environment variables
- cover the new compose planning and signing helpers with unit tests

## Testing
- cargo fmt
- cargo clippy --fix --allow-dirty --allow-staged --all-targets --all-features
- cargo clippy --all-targets --all-features
- cargo test --all-targets --all-features

------
https://chatgpt.com/codex/tasks/task_e_68d1a04b752883338fbcd977586ff145