### PR TITLE
feat: add delete support to blob stores

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1326,6 +1326,7 @@ dependencies = [
  "chrono",
  "futures",
  "google-cloud-auth",
+ "google-cloud-gax",
  "google-cloud-storage",
  "http 1.3.1",
  "http-body 1.0.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ bytes = { version = "1" }
 chrono = { version = "0.4", features = ["serde"] }
 futures = { version = "0.3.31" }
 google-cloud-auth = { version = "1" }
+google-cloud-gax = { version = "1" }
 google-cloud-storage = { version = "1" }
 http = { version = "1" }
 http-body = { version = "1" }

--- a/src/api/upload.rs
+++ b/src/api/upload.rs
@@ -349,6 +349,10 @@ mod tests {
                 url: Url::parse(u).unwrap(),
             }))
         }
+
+        async fn delete(&self, _key: &str) -> anyhow::Result<()> {
+            unimplemented!("not required for tests")
+        }
     }
 
     fn sample_row() -> CacheListRow {

--- a/src/http.rs
+++ b/src/http.rs
@@ -228,6 +228,10 @@ mod tests {
         ) -> anyhow::Result<Option<PresignedUrl>> {
             Ok(None)
         }
+
+        async fn delete(&self, _key: &str) -> anyhow::Result<()> {
+            Ok(())
+        }
     }
 
     fn test_config() -> Config {

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -41,4 +41,7 @@ pub trait BlobStore: Send + Sync + 'static {
     ) -> anyhow::Result<()>;
 
     async fn presign_get(&self, key: &str, ttl: Duration) -> anyhow::Result<Option<PresignedUrl>>;
+
+    #[allow(dead_code)]
+    async fn delete(&self, key: &str) -> anyhow::Result<()>;
 }

--- a/src/storage/s3.rs
+++ b/src/storage/s3.rs
@@ -170,6 +170,16 @@ impl BlobStore for S3Store {
         let url: url::Url = presigned.uri().to_string().parse()?;
         Ok(Some(PresignedUrl { url }))
     }
+
+    async fn delete(&self, key: &str) -> anyhow::Result<()> {
+        self.client
+            .delete_object()
+            .bucket(&self.bucket)
+            .key(key)
+            .send()
+            .await?;
+        Ok(())
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- add a delete API to `BlobStore` and implement it for the filesystem, S3, and GCS backends
- ensure filesystem deletions remove empty parent directories while remaining idempotent and covered by tests
- pull in `google-cloud-gax` to detect GCS NotFound responses when deleting

## Testing
- cargo fmt --all
- cargo clippy --fix --allow-dirty --allow-staged --all-targets --all-features
- cargo test --all-targets --all-features

------
https://chatgpt.com/codex/tasks/task_e_68d27c1cf4ac833392591f3e9f6b3a25