### PR TITLE
Refresh cache entry access timestamps on reads

### DIFF
--- a/src/api/download.rs
+++ b/src/api/download.rs
@@ -2,10 +2,13 @@ use axum::{
     extract::{Path, State},
     response::Redirect,
 };
+use sqlx::Row;
 use std::time::Duration;
+use uuid::Uuid;
 
 use crate::error::{ApiError, Result};
 use crate::http::AppState;
+use crate::meta;
 
 // GET /download/{random}/{filename}
 // We treat {random} as an opaque object key prefix (already known/stored in DB), and {filename} ignored for routing convenience
@@ -16,8 +19,15 @@ pub async fn download_proxy(
     if !st.enable_direct {
         return Err(ApiError::BadRequest("direct downloads disabled".into()));
     }
-    // Compose object key from opaque token; in real impl, map token->storage_key via DB
-    let storage_key = format!("dl/{random}"); // TODO: lookup token in DB to exact storage key
+    let entry_id =
+        Uuid::parse_str(&random).map_err(|_| ApiError::BadRequest("invalid cache id".into()))?;
+    let rec = sqlx::query("SELECT storage_key FROM cache_entries WHERE id = ?")
+        .bind(entry_id.to_string())
+        .fetch_optional(&st.pool)
+        .await?;
+    let row = rec.ok_or(ApiError::NotFound)?;
+    let storage_key: String = row.try_get("storage_key")?;
+    meta::touch_entry(&st.pool, entry_id).await?;
     let pres = st
         .store
         .presign_get(&storage_key, Duration::from_secs(3600))

--- a/src/api/twirp.rs
+++ b/src/api/twirp.rs
@@ -81,6 +81,7 @@ pub async fn get_cache_entry_download_url(
         .fetch_one(&st.pool)
         .await?;
     let storage_key: String = rec.try_get("storage_key")?;
+    meta::touch_entry(&st.pool, uuid).await?;
     let pres = st
         .store
         .presign_get(&storage_key, std::time::Duration::from_secs(3600))

--- a/src/api/upload.rs
+++ b/src/api/upload.rs
@@ -173,9 +173,11 @@ pub async fn get_cache_entry(
     .await?;
 
     if let Some(row) = rec {
+        let id = parse_uuid(row.try_get::<String, _>("id")?)?;
         let created_at = timestamp_to_datetime(row.try_get::<i64, _>("created_at")?)?;
         // Return 200 with archiveLocation (direct presigned URL); scope kept generic
         let storage_key: String = row.try_get("storage_key")?;
+        meta::touch_entry(&st.pool, id).await?;
         let url = st
             .store
             .presign_get(&storage_key, std::time::Duration::from_secs(3600))

--- a/src/meta/mod.rs
+++ b/src/meta/mod.rs
@@ -126,6 +126,16 @@ async fn fetch_entry(pool: &AnyPool, id: Uuid) -> Result<CacheEntry, sqlx::Error
     map_cache_entry(row)
 }
 
+pub async fn touch_entry(pool: &AnyPool, id: Uuid) -> Result<(), sqlx::Error> {
+    let now = Utc::now().timestamp();
+    sqlx::query("UPDATE cache_entries SET last_access_at = ? WHERE id = ?")
+        .bind(now)
+        .bind(id.to_string())
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
 pub async fn create_entry(
     pool: &AnyPool,
     org: &str,

--- a/tests/last_access.rs
+++ b/tests/last_access.rs
@@ -1,0 +1,208 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use axum::{
+    Json,
+    extract::{Path, Query, State},
+    response::IntoResponse,
+};
+use gha_cache_server::api::proxy::ProxyHttpClient;
+use gha_cache_server::api::types::TwirpGetUrlReq;
+use gha_cache_server::api::{download, twirp, upload};
+use gha_cache_server::http::AppState;
+use gha_cache_server::meta::{self, CacheEntry};
+use gha_cache_server::storage::{BlobStore, PresignedUrl};
+use http::Request;
+use sqlx::AnyPool;
+use sqlx::any::AnyPoolOptions;
+use url::Url;
+use uuid::Uuid;
+
+struct TestStore {
+    url: Url,
+}
+
+impl TestStore {
+    fn new(url: &str) -> Self {
+        Self {
+            url: Url::parse(url).expect("url"),
+        }
+    }
+}
+
+#[async_trait]
+impl BlobStore for TestStore {
+    async fn create_multipart(&self, _key: &str) -> anyhow::Result<String> {
+        unimplemented!("not used in tests");
+    }
+
+    async fn upload_part(
+        &self,
+        _key: &str,
+        _upload_id: &str,
+        _part_number: i32,
+        _body: gha_cache_server::storage::BlobUploadPayload,
+    ) -> anyhow::Result<String> {
+        unimplemented!("not used in tests");
+    }
+
+    async fn complete_multipart(
+        &self,
+        _key: &str,
+        _upload_id: &str,
+        _parts: Vec<(i32, String)>,
+    ) -> anyhow::Result<()> {
+        unimplemented!("not used in tests");
+    }
+
+    async fn presign_get(
+        &self,
+        _key: &str,
+        _ttl: Duration,
+    ) -> anyhow::Result<Option<PresignedUrl>> {
+        Ok(Some(PresignedUrl {
+            url: self.url.clone(),
+        }))
+    }
+
+    async fn delete(&self, _key: &str) -> anyhow::Result<()> {
+        Ok(())
+    }
+}
+
+#[derive(Clone)]
+struct DummyProxyClient;
+
+#[async_trait]
+impl ProxyHttpClient for DummyProxyClient {
+    async fn execute(
+        &self,
+        _request: Request<axum::body::Body>,
+    ) -> std::result::Result<axum::response::Response, axum::BoxError> {
+        panic!("proxy client should not be used in tests");
+    }
+}
+
+async fn setup_pool() -> AnyPool {
+    sqlx::any::install_default_drivers();
+    let pool = AnyPoolOptions::new()
+        .max_connections(1)
+        .connect("sqlite::memory:?cache=shared")
+        .await
+        .expect("connect sqlite");
+    sqlx::migrate!("./migrations/sqlite")
+        .run(&pool)
+        .await
+        .expect("run migrations");
+    pool
+}
+
+async fn create_entry(pool: &AnyPool) -> CacheEntry {
+    meta::create_entry(pool, "org", "repo", "cache-key", "scope", "storage-key")
+        .await
+        .expect("create entry")
+}
+
+async fn set_last_access(pool: &AnyPool, id: Uuid, value: i64) {
+    sqlx::query("UPDATE cache_entries SET last_access_at = ? WHERE id = ?")
+        .bind(value)
+        .bind(id.to_string())
+        .execute(pool)
+        .await
+        .expect("set last access");
+}
+
+async fn fetch_last_access(pool: &AnyPool, id: Uuid) -> i64 {
+    sqlx::query_scalar::<_, i64>("SELECT last_access_at FROM cache_entries WHERE id = ?")
+        .bind(id.to_string())
+        .fetch_one(pool)
+        .await
+        .expect("fetch last access")
+}
+
+fn build_state(pool: AnyPool) -> AppState {
+    AppState {
+        pool,
+        store: Arc::new(TestStore::new("https://example.com/archive.tgz")),
+        enable_direct: true,
+        proxy_client: Arc::new(DummyProxyClient),
+    }
+}
+
+#[tokio::test]
+async fn touch_entry_updates_last_access() {
+    let pool = setup_pool().await;
+    let entry = create_entry(&pool).await;
+    set_last_access(&pool, entry.id, 0).await;
+
+    meta::touch_entry(&pool, entry.id)
+        .await
+        .expect("touch entry");
+
+    let updated = fetch_last_access(&pool, entry.id).await;
+    assert!(updated > 0);
+}
+
+#[tokio::test]
+async fn get_cache_entry_updates_last_access() {
+    let pool = setup_pool().await;
+    let entry = create_entry(&pool).await;
+    set_last_access(&pool, entry.id, 1).await;
+
+    let state = build_state(pool.clone());
+    let mut query_params = HashMap::new();
+    query_params.insert("keys".to_string(), entry.key.clone());
+
+    let _ = upload::get_cache_entry(State(state), Query(query_params))
+        .await
+        .expect("cache hit");
+
+    let updated = fetch_last_access(&pool, entry.id).await;
+    assert!(updated > 1);
+}
+
+#[tokio::test]
+async fn twirp_download_url_updates_last_access() {
+    let pool = setup_pool().await;
+    let entry = create_entry(&pool).await;
+    set_last_access(&pool, entry.id, 2).await;
+
+    let state = build_state(pool.clone());
+    let request = TwirpGetUrlReq {
+        cache_id: entry.id.to_string(),
+    };
+
+    let _ = twirp::get_cache_entry_download_url(State(state), Json(request))
+        .await
+        .expect("twirp cache hit");
+
+    let updated = fetch_last_access(&pool, entry.id).await;
+    assert!(updated > 2);
+}
+
+#[tokio::test]
+async fn download_proxy_updates_last_access() {
+    let pool = setup_pool().await;
+    let entry = create_entry(&pool).await;
+    set_last_access(&pool, entry.id, 3).await;
+
+    let state = build_state(pool.clone());
+    let redirect = download::download_proxy(
+        State(state),
+        Path((entry.id.to_string(), "cache.tgz".to_string())),
+    )
+    .await
+    .expect("download redirect");
+
+    let response = redirect.into_response();
+    let location = response
+        .headers()
+        .get(http::header::LOCATION)
+        .expect("location header");
+    assert_eq!(location, "https://example.com/archive.tgz");
+
+    let updated = fetch_last_access(&pool, entry.id).await;
+    assert!(updated > 3);
+}


### PR DESCRIPTION
## Summary
- add a meta::touch_entry helper that refreshes a cache entry's last-access timestamp
- call touch_entry for REST, Twirp, and download proxy cache hits so read requests update activity
- cover the new behaviour with sqlite-backed integration tests that validate timestamp changes

## Testing
- cargo fmt --all
- cargo clippy --fix --allow-dirty --allow-staged --all-targets --all-features
- cargo test --all-targets --all-features


------
https://chatgpt.com/codex/tasks/task_e_68d284468d8883338a9e492cef274f8c