### PR TITLE
feat: add cache cleanup loop

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -46,3 +46,18 @@ When `BLOB_STORE=gcs`, configure the following environment variables:
 The GCS backend composes multipart uploads from temporary objects inside the
 target bucket and automatically issues V4-signed download URLs when direct
 downloads are enabled.
+
+## Cleanup settings
+
+The server periodically scans stored cache entries and deletes expired data. The
+following environment variables control this background job:
+
+* `CLEANUP_INTERVAL_SECS` – frequency of the cleanup loop in seconds. Defaults
+  to `300`. Values lower than `1` are coerced to `1` to avoid busy looping.
+* `CACHE_ENTRY_MAX_AGE_SECS` – optional override for the maximum age of a cache
+  entry. When set, entries are considered expired after the minimum between the
+  stored TTL and this value, regardless of the default TTL configured in the
+  database.
+* `CACHE_STORAGE_MAX_BYTES` – optional soft limit for the total size (in bytes)
+  of all cache entries. When the limit is exceeded, the cleanup loop removes the
+  least recently accessed entries until usage drops below the threshold.

--- a/src/cleanup.rs
+++ b/src/cleanup.rs
@@ -1,0 +1,87 @@
+use std::sync::Arc;
+
+use chrono::Utc;
+use sqlx::AnyPool;
+use tokio::time::{MissedTickBehavior, interval};
+use tracing::{debug, error, info, warn};
+
+use crate::config::CleanupSettings;
+use crate::meta::{self, CacheEntry};
+use crate::storage::BlobStore;
+
+pub async fn run_cleanup_loop(pool: AnyPool, store: Arc<dyn BlobStore>, settings: CleanupSettings) {
+    let mut ticker = interval(settings.interval);
+    ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
+
+    loop {
+        ticker.tick().await;
+
+        if let Err(err) = run_iteration(&pool, store.clone(), &settings).await {
+            error!(?err, "cleanup iteration failed");
+        }
+    }
+}
+
+async fn run_iteration(
+    pool: &AnyPool,
+    store: Arc<dyn BlobStore>,
+    settings: &CleanupSettings,
+) -> anyhow::Result<()> {
+    let now = Utc::now();
+
+    let expired = meta::expired_entries(pool, now, settings.max_entry_age).await?;
+    if !expired.is_empty() {
+        info!(count = expired.len(), "removing expired cache entries");
+    }
+    for entry in expired {
+        if remove_entry(pool, store.clone(), &entry).await {
+            debug!(entry_id = %entry.id, "deleted expired cache entry");
+        }
+    }
+
+    if let Some(limit) = settings.max_total_bytes {
+        let mut usage = meta::total_occupancy(pool).await?.max(0) as u64;
+        if usage > limit {
+            info!(current = usage, limit, "cache usage exceeds threshold");
+            let entries = meta::list_entries_ordered(pool, None).await?;
+            for entry in entries {
+                if usage <= limit {
+                    break;
+                }
+
+                if remove_entry(pool, store.clone(), &entry).await {
+                    let size = clamp_size(entry.size_bytes);
+                    usage = usage.saturating_sub(size);
+                    debug!(entry_id = %entry.id, size, usage, limit, "deleted entry to reclaim space");
+                }
+            }
+
+            if usage > limit {
+                warn!(
+                    current = usage,
+                    limit, "cleanup loop could not reduce usage below threshold"
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
+async fn remove_entry(pool: &AnyPool, store: Arc<dyn BlobStore>, entry: &CacheEntry) -> bool {
+    if let Err(err) = store.delete(&entry.storage_key).await {
+        error!(entry_id = %entry.id, storage_key = %entry.storage_key, ?err, "failed to delete blob");
+        return false;
+    }
+
+    if let Err(err) = meta::delete_entry(pool, entry.id).await {
+        error!(entry_id = %entry.id, ?err, "failed to delete cache entry metadata");
+        return false;
+    }
+
+    true
+}
+
+fn clamp_size(value: i64) -> u64 {
+    if value < 0 { 0 } else { value as u64 }
+}

--- a/src/http.rs
+++ b/src/http.rs
@@ -123,7 +123,7 @@ mod tests {
     use tower::ServiceExt;
 
     use crate::api::proxy::{self, ProxyHttpClient, RESULTS_RECEIVER_ORIGIN};
-    use crate::config::{BlobStoreSelector, Config, DatabaseDriver, S3Config};
+    use crate::config::{BlobStoreSelector, CleanupSettings, Config, DatabaseDriver, S3Config};
     use crate::storage::{BlobStore, PresignedUrl};
 
     #[derive(Clone, Debug)]
@@ -251,6 +251,11 @@ mod tests {
             }),
             fs: None,
             gcs: None,
+            cleanup: CleanupSettings {
+                interval: Duration::from_secs(300),
+                max_entry_age: None,
+                max_total_bytes: None,
+            },
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod api;
+pub mod cleanup;
 pub mod config;
 pub mod error;
 pub mod http;


### PR DESCRIPTION
## Summary
- add cleanup configuration options and document the new environment variables
- implement a background cleanup loop that removes expired entries and enforces a storage limit
- wire the cleanup loop into the server startup and cover it with end-to-end tests

## Testing
- cargo fmt
- cargo clippy --all-targets --all-features
- cargo test --all-targets --all-features

------
https://chatgpt.com/codex/tasks/task_e_68d2bc6f7cc883339a708fb49812da8a