### PR TITLE
Add crate metadata and documentation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,13 @@
 name = "gha-cache-server"
 version = "1.0.0"
 edition = "2024"
+description = "Self-hosted compatibility server for the GitHub Actions cache API."
+license = "MIT"
+homepage = "https://github.com/actions/gha-cache-server"
+repository = "https://github.com/actions/gha-cache-server"
+documentation = "https://github.com/actions/gha-cache-server/tree/main/docs"
+readme = "README.md"
+default-run = "gha-cache-server"
 
 [dependencies]
 anyhow = { version = "1" }

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Alessandro Chitolina
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+# GHA Cache Server
+
+The GHA Cache Server is a Rust implementation of the GitHub Actions cache
+service. It exposes the same HTTP surface as the hosted Actions cache so that
+self-managed runners can share build artifacts across jobs and workflows.
+
+## Prerequisites
+
+Before starting the server make sure the following requirements are satisfied:
+
+- `DATABASE_URL` – connection string for the PostgreSQL, MySQL or SQLite
+  database that stores cache metadata. The URL must use one of the supported
+  drivers described in `src/config.rs` and be reachable from the running
+  process.
+- Blob storage backend – select the backend with the `BLOB_STORE` environment
+  variable and provide the backend-specific configuration. The server ships with
+  S3, Google Cloud Storage and filesystem implementations. See the
+  [configuration guide](docs/configuration.md) for the full list of options and
+  environment variables.
+
+## Running locally
+
+With the prerequisites in place you can start the server with Cargo:
+
+```bash
+cargo run --release
+```
+
+By default the binary listens on port `8080`. Additional runtime options are
+available through environment variables; refer to the documentation linked
+above for details.
+
+## Additional documentation
+
+Further configuration topics, including cleanup controls and advanced storage
+settings, are documented in [`docs/configuration.md`](docs/configuration.md).


### PR DESCRIPTION
## Summary
- add descriptive metadata to the crate manifest and configure the default binary
- introduce a README with prerequisites, usage instructions, and configuration pointers
- include the MIT license text in the repository root

## Testing
- cargo fmt --all
- cargo clippy --fix --allow-dirty --allow-staged --all-targets --all-features
- cargo test --all-targets --all-features
- cargo metadata --format-version 1 --no-deps | python -m json.tool
- cargo package --allow-dirty

------
https://chatgpt.com/codex/tasks/task_e_68d2c7abcc908333bee5fe27e5988115