### PR TITLE
feat: add container image build pipeline

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+/target
+/.git
+/.github
+/tests
+/docs
+/_data
+/debian
+/packaging
+/migrations/*.sql.swp
+.DS_Store

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,0 +1,47 @@
+name: Container image
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+  workflow_dispatch:
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+            type=ref,event=tag
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,47 @@
+# syntax=docker/dockerfile:1.18
+
+FROM rust:1.90 AS builder
+LABEL org.opencontainers.image.source="https://github.com/n-cloud-labs/gha-cache-server"
+WORKDIR /usr/src/gha-cache-server
+
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y build-essential cmake pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create a dummy project to leverage Docker layer caching for dependencies
+COPY Cargo.toml Cargo.lock ./
+RUN mkdir src \
+    && echo "fn main() {}" > src/main.rs \
+    && cargo build --release --locked \
+    && rm -rf target/release
+
+# Copy the full source tree and build the release binary
+COPY . .
+RUN cargo build --release --locked --bin gha-cache-server
+
+RUN mkdir -p /out/usr/local/bin /out/srv/gha-cache-server \
+    && cp target/release/gha-cache-server /out/usr/local/bin/gha-cache-server \
+    && cp -r migrations /out/srv/gha-cache-server/
+
+FROM bitnami/minideb:bookworm AS runtime
+LABEL org.opencontainers.image.source="https://github.com/n-cloud-labs/gha-cache-server"
+WORKDIR /srv/gha-cache-server
+
+RUN install_packages ca-certificates
+
+# Default configuration values. Override them with environment variables at runtime.
+ENV PORT=8080 \
+    RUST_LOG=info,github_actions_cache_rs=info \
+    MAX_CONCURRENCY=64 \
+    REQUEST_TIMEOUT_SECS=3600 \
+    ENABLE_DIRECT_DOWNLOADS=true \
+    BLOB_STORE=fs \
+    FS_ROOT=/var/lib/gha-cache-server \
+    DATABASE_URL=postgres://postgres:postgres@postgres:5432/cache
+
+COPY --from=builder /out/ /
+
+VOLUME ["/var/lib/gha-cache-server"]
+EXPOSE 8080
+
+ENTRYPOINT ["/usr/local/bin/gha-cache-server"]

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,12 +1,39 @@
 services:
+  gha-cache-server:
+    image: ghcr.io/n-cloud-labs/gha-cache-server:latest
+    depends_on:
+      postgres:
+        condition: service_healthy
+      minio:
+        condition: service_started
+    environment:
+      PORT: 8080
+      RUST_LOG: info,github_actions_cache_rs=info
+      DATABASE_URL: postgres://postgres:postgres@postgres:5432/cache
+      BLOB_STORE: s3
+      S3_BUCKET: cache
+      AWS_ACCESS_KEY_ID: minioadmin
+      AWS_SECRET_ACCESS_KEY: minioadmin
+      AWS_REGION: us-east-1
+      AWS_ENDPOINT_URL: http://minio:9000
+      S3_FORCE_PATH_STYLE: "true"
+      ENABLE_DIRECT_DOWNLOADS: "true"
+    ports:
+      - "8080:8080"
+
   postgres:
     image: ghcr.io/bitcompat/postgresql:16
     environment:
       POSTGRESQL_PASSWORD: postgres
       POSTGRESQL_USER: postgres
       POSTGRESQL_DB: cache
-    ports: ["5432:5432"]
-
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d cache"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    ports:
+      - "5432:5432"
 
   minio:
     image: quay.io/minio/minio:latest
@@ -14,6 +41,8 @@ services:
     environment:
       MINIO_ROOT_USER: minioadmin
       MINIO_ROOT_PASSWORD: minioadmin
-    ports: ["9000:9000", "9001:9001"]
+    ports:
+      - "9000:9000"
+      - "9001:9001"
     volumes:
       - ./_data/minio:/data

--- a/docs/container-image.md
+++ b/docs/container-image.md
@@ -1,0 +1,58 @@
+# Container image
+
+The project ships a container image published on GitHub Container Registry
+(`ghcr.io/n-cloud-labs/gha-cache-server`). The image is based on minideb and
+includes the compiled `gha-cache-server` binary together with the SQL migration
+files required at runtime.
+
+## Runtime configuration
+
+Environment variables are used to configure the server. The Dockerfile sets
+sensible defaults to help local development:
+
+- `PORT` (default `8080`) – HTTP listening port exposed by the container.
+- `RUST_LOG` – tracing filter used by the application.
+- `MAX_CONCURRENCY` – maximum number of concurrent API requests.
+- `REQUEST_TIMEOUT_SECS` – request timeout applied by the tower middleware.
+- `ENABLE_DIRECT_DOWNLOADS` – toggle direct download URLs when supported by the
+  blob backend.
+- `BLOB_STORE` – selects the blob storage backend (`fs`, `s3` or `gcs`).
+- `FS_ROOT` – storage path used by the filesystem backend. A persistent volume is
+  declared for `/var/lib/gha-cache-server` so that `BLOB_STORE=fs` survives
+  container restarts.
+- `DATABASE_URL` – connection string for the SQL database. The default assumes a
+  Postgres server named `postgres` inside the same Docker Compose project.
+
+Override these values with your own configuration when running the container.
+
+## Docker Compose example
+
+The repository includes a `compose.yaml` file that wires the application with
+Postgres and MinIO (S3-compatible) services:
+
+```sh
+docker compose up --build
+```
+
+The stack exposes the following services on the host machine:
+
+- `gha-cache-server` on port `8080` (HTTP API).
+- `postgres` on port `5432` (PostgreSQL).
+- `minio` on ports `9000` (S3 endpoint) and `9001` (console UI).
+
+When switching to the filesystem backend (`BLOB_STORE=fs`), mount a persistent
+volume on `/var/lib/gha-cache-server` to retain cache artifacts:
+
+```yaml
+services:
+  gha-cache-server:
+    image: ghcr.io/n-cloud-labs/gha-cache-server:latest
+    environment:
+      BLOB_STORE: fs
+      FS_ROOT: /var/lib/gha-cache-server
+    volumes:
+      - gha-cache-data:/var/lib/gha-cache-server
+
+volumes:
+  gha-cache-data:
+```


### PR DESCRIPTION
## Summary
- add a multi-stage Dockerfile that produces a slim runtime image with documented defaults and filesystem volume support, now built with docker/dockerfile 1.18, a rust:1.90 builder, and a bitnami/minideb runtime with a single copy into the final stage
- update the Compose example and provide container documentation for running with Postgres and MinIO
- introduce a GitHub Actions workflow to publish the image to GHCR with latest and version tags
- align the container documentation with the minideb base image

## Testing
- not run (not required for this change)

------
https://chatgpt.com/codex/tasks/task_e_68d456ecaae08333acbe6743ad1f44f4