### PR TITLE
Fix SQL placeholders for AnyPool drivers

### DIFF
--- a/src/api/upload_compat.rs
+++ b/src/api/upload_compat.rs
@@ -4,6 +4,7 @@ use sqlx::Row;
 use uuid::Uuid;
 
 use crate::api::upload::body_to_blob_payload;
+use crate::db::rewrite_placeholders;
 use crate::error::{ApiError, Result};
 use crate::http::AppState;
 use crate::meta;
@@ -16,22 +17,26 @@ pub async fn put_upload(
     body: axum::body::Body,
 ) -> Result<StatusCode> {
     let uuid = Uuid::parse_str(&id).map_err(|_| ApiError::BadRequest("invalid cacheId".into()))?;
-    let rec = sqlx::query(
+    let query = rewrite_placeholders(
         "SELECT upload_id, storage_key FROM cache_uploads u JOIN cache_entries e ON e.id = u.entry_id WHERE e.id = ?",
-    )
-    .bind(uuid.to_string())
-    .fetch_one(&st.pool)
-    .await?;
+        st.database_driver,
+    );
+    let rec = sqlx::query(&query)
+        .bind(uuid.to_string())
+        .fetch_one(&st.pool)
+        .await?;
     let upload_id: String = rec.try_get("upload_id")?;
     let storage_key: String = rec.try_get("storage_key")?;
 
-    let part_no = 1 + meta::get_parts(&st.pool, &upload_id).await?.len() as i32;
+    let part_no = 1 + meta::get_parts(&st.pool, st.database_driver, &upload_id)
+        .await?
+        .len() as i32;
     let bs = body_to_blob_payload(body);
     let etag = st
         .store
         .upload_part(&storage_key, &upload_id, part_no, bs)
         .await
         .map_err(|e| ApiError::S3(format!("{e}")))?;
-    meta::add_part(&st.pool, &upload_id, part_no, &etag).await?;
+    meta::add_part(&st.pool, st.database_driver, &upload_id, part_no, &etag).await?;
     Ok(StatusCode::OK)
 }

--- a/src/cleanup.rs
+++ b/src/cleanup.rs
@@ -5,18 +5,23 @@ use sqlx::AnyPool;
 use tokio::time::{MissedTickBehavior, interval};
 use tracing::{debug, error, info, warn};
 
-use crate::config::CleanupSettings;
+use crate::config::{CleanupSettings, DatabaseDriver};
 use crate::meta::{self, CacheEntry};
 use crate::storage::BlobStore;
 
-pub async fn run_cleanup_loop(pool: AnyPool, store: Arc<dyn BlobStore>, settings: CleanupSettings) {
+pub async fn run_cleanup_loop(
+    pool: AnyPool,
+    store: Arc<dyn BlobStore>,
+    settings: CleanupSettings,
+    driver: DatabaseDriver,
+) {
     let mut ticker = interval(settings.interval);
     ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
     loop {
         ticker.tick().await;
 
-        if let Err(err) = run_iteration(&pool, store.clone(), &settings).await {
+        if let Err(err) = run_iteration(&pool, store.clone(), &settings, driver).await {
             error!(?err, "cleanup iteration failed");
         }
     }
@@ -26,30 +31,31 @@ async fn run_iteration(
     pool: &AnyPool,
     store: Arc<dyn BlobStore>,
     settings: &CleanupSettings,
+    driver: DatabaseDriver,
 ) -> anyhow::Result<()> {
     let now = Utc::now();
 
-    let expired = meta::expired_entries(pool, now, settings.max_entry_age).await?;
+    let expired = meta::expired_entries(pool, driver, now, settings.max_entry_age).await?;
     if !expired.is_empty() {
         info!(count = expired.len(), "removing expired cache entries");
     }
     for entry in expired {
-        if remove_entry(pool, store.clone(), &entry).await {
+        if remove_entry(pool, driver, store.clone(), &entry).await {
             debug!(entry_id = %entry.id, "deleted expired cache entry");
         }
     }
 
     if let Some(limit) = settings.max_total_bytes {
-        let mut usage = meta::total_occupancy(pool).await?.max(0) as u64;
+        let mut usage = meta::total_occupancy(pool, driver).await?.max(0) as u64;
         if usage > limit {
             info!(current = usage, limit, "cache usage exceeds threshold");
-            let entries = meta::list_entries_ordered(pool, None).await?;
+            let entries = meta::list_entries_ordered(pool, driver, None).await?;
             for entry in entries {
                 if usage <= limit {
                     break;
                 }
 
-                if remove_entry(pool, store.clone(), &entry).await {
+                if remove_entry(pool, driver, store.clone(), &entry).await {
                     let size = clamp_size(entry.size_bytes);
                     usage = usage.saturating_sub(size);
                     debug!(entry_id = %entry.id, size, usage, limit, "deleted entry to reclaim space");
@@ -68,13 +74,18 @@ async fn run_iteration(
     Ok(())
 }
 
-async fn remove_entry(pool: &AnyPool, store: Arc<dyn BlobStore>, entry: &CacheEntry) -> bool {
+async fn remove_entry(
+    pool: &AnyPool,
+    driver: DatabaseDriver,
+    store: Arc<dyn BlobStore>,
+    entry: &CacheEntry,
+) -> bool {
     if let Err(err) = store.delete(&entry.storage_key).await {
         error!(entry_id = %entry.id, storage_key = %entry.storage_key, ?err, "failed to delete blob");
         return false;
     }
 
-    if let Err(err) = meta::delete_entry(pool, entry.id).await {
+    if let Err(err) = meta::delete_entry(pool, driver, entry.id).await {
         error!(entry_id = %entry.id, ?err, "failed to delete cache entry metadata");
         return false;
     }

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,0 +1,28 @@
+use std::borrow::Cow;
+
+use crate::config::DatabaseDriver;
+
+pub fn rewrite_placeholders<'q>(sql: &'q str, driver: DatabaseDriver) -> Cow<'q, str> {
+    if driver != DatabaseDriver::Postgres {
+        return Cow::Borrowed(sql);
+    }
+
+    if !sql.contains('?') {
+        return Cow::Borrowed(sql);
+    }
+
+    let mut result = String::with_capacity(sql.len());
+    let mut index = 1;
+
+    for ch in sql.chars() {
+        if ch == '?' {
+            result.push('$');
+            result.push_str(&index.to_string());
+            index += 1;
+        } else {
+            result.push(ch);
+        }
+    }
+
+    Cow::Owned(result)
+}

--- a/src/http.rs
+++ b/src/http.rs
@@ -14,7 +14,7 @@ use tower::{
 };
 
 use crate::api::{download, proxy, twirp, upload, upload_compat};
-use crate::config::Config;
+use crate::config::{Config, DatabaseDriver};
 use crate::storage::BlobStore;
 
 #[derive(Clone)]
@@ -23,6 +23,7 @@ pub struct AppState {
     pub store: Arc<dyn BlobStore>,
     pub enable_direct: bool,
     pub proxy_client: Arc<dyn proxy::ProxyHttpClient>,
+    pub database_driver: DatabaseDriver,
 }
 
 pub fn build_router(pool: AnyPool, store: Arc<dyn BlobStore>, cfg: &Config) -> Router {
@@ -42,6 +43,7 @@ pub(crate) fn build_router_with_proxy(
         store,
         enable_direct: cfg.enable_direct_downloads,
         proxy_client,
+        database_driver: cfg.database_driver,
     };
 
     Router::new()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod api;
 pub mod cleanup;
 pub mod config;
+pub mod db;
 pub mod error;
 pub mod http;
 pub mod meta;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod api;
 mod cleanup;
 mod config;
+mod db;
 mod error;
 mod http;
 mod meta;
@@ -101,8 +102,15 @@ async fn main() -> anyhow::Result<()> {
     let cleanup_settings = cfg.cleanup.clone();
     let cleanup_pool = pool.clone();
     let cleanup_store = store.clone();
+    let cleanup_driver = cfg.database_driver;
     let cleanup_task = tokio::spawn(async move {
-        cleanup::run_cleanup_loop(cleanup_pool, cleanup_store, cleanup_settings).await;
+        cleanup::run_cleanup_loop(
+            cleanup_pool,
+            cleanup_store,
+            cleanup_settings,
+            cleanup_driver,
+        )
+        .await;
     });
 
     let addr = SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), cfg.port);


### PR DESCRIPTION
## Summary
- add a helper that rewrites `?` placeholders to driver-specific syntax
- thread the configured database driver through app state, meta queries, cleanup, and APIs so every query uses the helper

## Testing
- cargo clippy --fix --allow-dirty --allow-staged --all-targets --all-features
- cargo test --all-targets --all-features

------
https://chatgpt.com/codex/tasks/task_e_68d5d9c0513c833384bcb5ed453b41c0