### PR TITLE
Add streaming fallback for cache downloads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1456,6 +1456,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "tokio-util",
  "tower",
  "tower-http",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ sqlx = { version = "0.8", features = ["any", "chrono", "migrate", "mysql", "post
 sync_wrapper = { version = "1" }
 thiserror = { version = "2" }
 tokio = { version = "1", features = ["fs", "io-util", "macros", "rt-multi-thread", "signal"] }
+tokio-util = { version = "0.7", features = ["io"] }
 tower = { version = "0.5", features = ["timeout", "limit"] }
 tower-http = { version = "0.6", features = ["trace"] }
 tracing = { version = "0.1" }

--- a/docs/cache-protocol.md
+++ b/docs/cache-protocol.md
@@ -85,10 +85,14 @@ Response on success:
 ```json
 {
   "ok": true,
-  "signed_download_url": "https://...",
+  "signed_download_url": "/download/<cache-id>/cache.tgz",
   "matched_key": "primary"
 }
 ```
+
+When direct downloads are enabled and the backing blob store can issue
+presigned URLs, the `signed_download_url` field instead contains the direct
+link to the object.
 
 The handler evaluates `key` followed by the optional `restore_keys` array until
 it finds a cache entry with the matching version. When nothing matches the

--- a/docs/cache-protocol.md
+++ b/docs/cache-protocol.md
@@ -85,7 +85,7 @@ Response on success:
 ```json
 {
   "ok": true,
-  "signed_download_url": "/download/<cache-id>/cache.tgz",
+  "signed_download_url": "https://<host>/download/<cache-key>/<cache-id>.tgz",
   "matched_key": "primary"
 }
 ```

--- a/src/api/upload.rs
+++ b/src/api/upload.rs
@@ -390,7 +390,7 @@ pub async fn commit_cache(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::storage::{BlobStore, BlobUploadPayload, PresignedUrl};
+    use crate::storage::{BlobDownloadStream, BlobStore, BlobUploadPayload, PresignedUrl};
     use async_trait::async_trait;
     use std::sync::{
         Arc,
@@ -451,6 +451,10 @@ mod tests {
             Ok(self.url.as_ref().map(|u| PresignedUrl {
                 url: Url::parse(u).unwrap(),
             }))
+        }
+
+        async fn get(&self, _key: &str) -> anyhow::Result<Option<BlobDownloadStream>> {
+            Ok(None)
         }
 
         async fn delete(&self, _key: &str) -> anyhow::Result<()> {

--- a/src/http.rs
+++ b/src/http.rs
@@ -69,8 +69,11 @@ pub(crate) fn build_router_with_proxy(
             post(upload::commit_cache),
         )
         // ===== Extra routes you asked =====
-        // 1) GET /download/{random}/{filename}
-        .route("/download/:random/:filename", get(download::download_proxy))
+        // 1) GET /download/{cache_key}/{filename}
+        .route(
+            "/download/:cache_key/:filename",
+            get(download::download_proxy),
+        )
         // 2) TWIRP endpoints
         .route(
             "/twirp/github.actions.results.api.v1.CacheService/CreateCacheEntry",

--- a/src/http.rs
+++ b/src/http.rs
@@ -127,7 +127,7 @@ mod tests {
 
     use crate::api::proxy::{self, ProxyHttpClient, RESULTS_RECEIVER_ORIGIN};
     use crate::config::{BlobStoreSelector, CleanupSettings, Config, DatabaseDriver, S3Config};
-    use crate::storage::{BlobStore, PresignedUrl};
+    use crate::storage::{BlobDownloadStream, BlobStore, PresignedUrl};
 
     #[derive(Clone, Debug)]
     struct RecordedRequest {
@@ -229,6 +229,10 @@ mod tests {
             _key: &str,
             _ttl: Duration,
         ) -> anyhow::Result<Option<PresignedUrl>> {
+            Ok(None)
+        }
+
+        async fn get(&self, _key: &str) -> anyhow::Result<Option<BlobDownloadStream>> {
             Ok(None)
         }
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -16,7 +16,9 @@ pub struct PresignedUrl {
 /// The stream yields the raw body of a single part and propagates failures via
 /// [`anyhow::Error`]. Implementations must consume the stream at most once and
 /// either upload the entire payload or report an error.
-pub type BlobUploadPayload = BoxStream<'static, anyhow::Result<Bytes>>;
+pub type BlobStream = BoxStream<'static, anyhow::Result<Bytes>>;
+pub type BlobUploadPayload = BlobStream;
+pub type BlobDownloadStream = BlobStream;
 
 #[async_trait]
 pub trait BlobStore: Send + Sync + 'static {
@@ -41,6 +43,8 @@ pub trait BlobStore: Send + Sync + 'static {
     ) -> anyhow::Result<()>;
 
     async fn presign_get(&self, key: &str, ttl: Duration) -> anyhow::Result<Option<PresignedUrl>>;
+
+    async fn get(&self, key: &str) -> anyhow::Result<Option<BlobDownloadStream>>;
 
     #[allow(dead_code)]
     async fn delete(&self, key: &str) -> anyhow::Result<()>;


### PR DESCRIPTION
## Summary
- stream cache downloads through the server when presigned URLs are unavailable
- surface the download proxy URL from GetCacheEntryDownloadURL and document the behaviour
- extend the blob store trait with streaming reads and implement it for the file system, GCS, and S3 backends

## Testing
- cargo fmt --all
- cargo clippy --fix --allow-dirty --allow-staged --all-targets --all-features
- cargo test --all-targets --all-features

------
https://chatgpt.com/codex/tasks/task_e_68d6a721e4148333b5f988c9e082176f