### PR TITLE
ci: enable sccache across workflows

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -21,6 +21,10 @@ concurrency:
   cancel-in-progress: true
   group: ${{ github.workflow }}-${{ github.ref }}
 
+env:
+  RUSTC_WRAPPER: sccache
+  SCCACHE_GHA_ENABLED: true
+
 jobs:
   check-clippy:
     runs-on: ubuntu-24.04
@@ -35,7 +39,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-all-crates: 'true'
-      - name: Install protobuf compiler
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+      - name: Install protobuf compiler and sccache
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler sccache
       - name: Run clippy
         run: cargo clippy --all-targets --all-features -- -D warnings

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -27,6 +27,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  RUSTC_WRAPPER: sccache
+  SCCACHE_GHA_ENABLED: true
+
 jobs:
   build-deb:
     strategy:
@@ -42,7 +46,7 @@ jobs:
       - name: Install build dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential debhelper pkg-config protobuf-compiler cargo rustc
+          sudo apt-get install -y build-essential debhelper pkg-config protobuf-compiler cargo rustc sccache
 
       - name: Install Rust toolchain
         run: |

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -21,11 +21,17 @@ concurrency:
   cancel-in-progress: true
   group: ${{ github.workflow }}-${{ github.ref }}
 
+env:
+  RUSTC_WRAPPER: sccache
+  SCCACHE_GHA_ENABLED: true
+
 jobs:
   check-format:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
+      - name: Install sccache
+        run: sudo apt-get update && sudo apt-get install -y sccache
       - name: Install Rust toolchain
         run: |-
           command -v rustup || ( curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --component rustfmt )

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   CHART_DIR: deploy/charts/gha-cache-server
+  RUSTC_WRAPPER: sccache
+  SCCACHE_GHA_ENABLED: true
 
 jobs:
   prepare:
@@ -90,7 +92,7 @@ jobs:
         if: matrix.target == 'debian'
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential debhelper devscripts debsigs pkg-config protobuf-compiler
+          sudo apt-get install -y build-essential debhelper devscripts debsigs pkg-config protobuf-compiler sccache
 
       - name: Prepare Debian metadata
         if: matrix.target == 'debian'
@@ -156,6 +158,10 @@ jobs:
           set -euo pipefail
           docker run --rm \
             -e RELEASE_VERSION="${RELEASE_VERSION}" \
+            -e RUSTC_WRAPPER \
+            -e SCCACHE_GHA_ENABLED \
+            -e ACTIONS_RESULTS_URL \
+            -e ACTIONS_RUNTIME_TOKEN \
             -v "$PWD":/src \
             -w /src \
             registry.fedoraproject.org/fedora:42 \
@@ -166,7 +172,7 @@ jobs:
               echo "keepcache=True" >> /etc/dnf/dnf.conf
               dnf -y update
               dnf -y group install development-tools
-              dnf -y install rpm-build rpmdevtools systemd-rpm-macros cmake pkgconfig protobuf-compiler git curl which tar
+              dnf -y install rpm-build rpmdevtools systemd-rpm-macros cmake pkgconfig protobuf-compiler git curl which tar sccache
               curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain stable
               source "$HOME/.cargo/env"
               rustup default stable
@@ -231,18 +237,22 @@ jobs:
           docker run --rm \
             -e RELEASE_VERSION="${RELEASE_VERSION}" \
             -e PACKAGE_VERSION="${PACKAGE_VERSION}" \
+            -e RUSTC_WRAPPER \
+            -e SCCACHE_GHA_ENABLED \
+            -e ACTIONS_RESULTS_URL \
+            -e ACTIONS_RUNTIME_TOKEN \
             -v "$PWD":/src \
             -w /src \
             archlinux:latest \
             bash -c '
               set -euo pipefail
               pacman -Sy --noconfirm archlinux-keyring
-              pacman -Syu --noconfirm base-devel git rustup clang protobuf
+              pacman -Syu --noconfirm base-devel git rustup clang protobuf sccache sudo
               useradd -m builder
               echo "builder ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/builder
               chmod 0440 /etc/sudoers.d/builder
               chown builder:builder /src -R
-              su builder -c "
+              sudo -E -u builder bash -c "
                 set -euo pipefail
                 cd /src
                 rustup install stable

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -25,6 +25,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  RUSTC_WRAPPER: sccache
+  SCCACHE_GHA_ENABLED: true
+
 jobs:
   build-rpm:
     strategy:
@@ -45,7 +49,7 @@ jobs:
           keepcache=True
           EOT
           dnf -y group install development-tools
-          dnf -y install git rpm-build rpmdevtools systemd-rpm-macros cmake pkgconfig protobuf-compiler which curl tar
+          dnf -y install git rpm-build rpmdevtools systemd-rpm-macros cmake pkgconfig protobuf-compiler which curl tar sccache
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain stable

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,10 @@ concurrency:
   cancel-in-progress: true
   group: ${{ github.workflow }}-${{ github.ref }}
 
+env:
+  RUSTC_WRAPPER: sccache
+  SCCACHE_GHA_ENABLED: true
+
 jobs:
   check-postgres:
     runs-on: ubuntu-24.04
@@ -50,8 +54,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-all-crates: 'true'
-      - name: Install required packages
-        run: sudo apt-get update && sudo apt-get install -y postgresql-client protobuf-compiler
+      - name: Install required packages and sccache
+        run: sudo apt-get update && sudo apt-get install -y postgresql-client protobuf-compiler sccache
       - name: Install sqlx-cli
         run: cargo install sqlx-cli --no-default-features --features native-tls,postgres,mysql,sqlite
       - name: Prepare database
@@ -89,8 +93,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-all-crates: 'true'
-      - name: Install required packages
-        run: sudo apt-get update && sudo apt-get install -y default-mysql-client protobuf-compiler
+      - name: Install required packages and sccache
+        run: sudo apt-get update && sudo apt-get install -y default-mysql-client protobuf-compiler sccache
       - name: Install sqlx-cli
         run: cargo install sqlx-cli --no-default-features --features native-tls,postgres,mysql,sqlite
       - name: Prepare database
@@ -116,8 +120,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-all-crates: 'true'
-      - name: Install required packages
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+      - name: Install required packages and sccache
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler sccache
       - name: Install sqlx-cli
         run: cargo install sqlx-cli --no-default-features --features native-tls,postgres,mysql,sqlite
       - name: Prepare database


### PR DESCRIPTION
## Summary
- enable sccache for Rust compilation across CI workflows
- ensure runners and build containers install sccache before building
- pass required GitHub Actions environment through dockerized package builds

## Testing
- not run (workflow-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d6bbee368483338b6211db5aff7ad1