### PR TITLE
feat: log api error responses

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -30,6 +30,13 @@ impl IntoResponse for ApiError {
             ApiError::S3(e) => (StatusCode::BAD_GATEWAY, format!("s3: {}", e)),
             ApiError::Internal(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.clone()),
         };
+
+        if code.is_client_error() {
+            tracing::warn!(status = %code, error = %self, "returning API error response");
+        } else {
+            tracing::error!(status = %code, error = %self, "returning API error response");
+        }
+
         (code, Json(Problem { message: msg })).into_response()
     }
 }


### PR DESCRIPTION
## Summary
- log proxied error responses including the response body to aid debugging
- log API error responses emitted directly by this service so every failure is captured

## Testing
- cargo fmt --all
- cargo clippy --fix --allow-dirty --allow-staged --all-targets --all-features
- cargo test --all-targets --all-features

------
https://chatgpt.com/codex/tasks/task_e_68d7abe175648333a403a840994ad9c4