### PR TITLE
fix: return numeric entry id in finalize response

### DIFF
--- a/docs/cache-protocol.md
+++ b/docs/cache-protocol.md
@@ -110,12 +110,12 @@ upload by calling:
 Response:
 
 ```json
-{ "ok": true, "entry_id": "uuid" }
+{ "ok": true, "entry_id": 123456789 }
 ```
 
 The lookup is performed against the key/version pair and succeeds when the cache
 entry exists and has an associated upload session. When the lookup fails the
-server returns `ok: false` with an empty identifier.
+server returns `ok: false` with a zero identifier.
 
 ## Database schema
 

--- a/src/api/twirp.rs
+++ b/src/api/twirp.rs
@@ -300,7 +300,7 @@ pub async fn finalize_cache_entry_upload(
         return Ok(TwirpResponse::new(
             TwirpFinalizeResp {
                 ok: false,
-                entry_id: String::new(),
+                entry_id: 0,
             },
             format,
         ));
@@ -324,7 +324,7 @@ pub async fn finalize_cache_entry_upload(
     Ok(TwirpResponse::new(
         TwirpFinalizeResp {
             ok: true,
-            entry_id: entry.id.to_string(),
+            entry_id: uuid_to_i64(entry.id),
         },
         format,
     ))


### PR DESCRIPTION
## Summary
- return numeric cache entry identifiers from the Twirp finalize response
- convert UUID cache IDs to i64 values before serializing responses and update documentation

## Testing
- cargo fmt --all
- cargo clippy --all-targets --all-features
- cargo test --all-targets --all-features

------
https://chatgpt.com/codex/tasks/task_e_68d7e8dcb05c8333a2e5c663bfff4e21