### PR TITLE
fix: sort multipart parts before finalize

### DIFF
--- a/src/meta/mod.rs
+++ b/src/meta/mod.rs
@@ -393,6 +393,7 @@ pub async fn get_parts(
     driver: DatabaseDriver,
     upload_id: &str,
 ) -> Result<Vec<(i32, String)>, sqlx::Error> {
-    let parts = fetch_parts(pool, driver, upload_id).await?;
+    let mut parts = fetch_parts(pool, driver, upload_id).await?;
+    parts.sort_by_key(|part| part.part_number);
     Ok(parts.into_iter().map(|p| (p.part_number, p.etag)).collect())
 }


### PR DESCRIPTION
## Summary
- sort multipart upload parts by their part numbers before completing the upload

## Testing
- cargo clippy --fix --allow-dirty --allow-staged --all-targets --all-features
- cargo test --all-targets --all-features

------
https://chatgpt.com/codex/tasks/task_e_68d7ed78dd2c8333987d2f314133b5e8