### PR TITLE
feat: add filesystem upload staging and purge command

### DIFF
--- a/deploy/charts/gha-cache-server/README.md
+++ b/deploy/charts/gha-cache-server/README.md
@@ -80,8 +80,20 @@ provision a PersistentVolumeClaim or reuse an existing one:
 fsBackend:
   enabled: true
   mountPath: /var/lib/gha-cache
+  uploadRoot: /var/lib/gha-cache-uploads
   size: 200Gi
+  uploads:
+    enabled: true
+    mountPath: /var/lib/gha-cache-uploads
+    size: 50Gi
 ```
+
+When `uploadRoot` is set (explicitly or via the `.fsBackend.uploads.mountPath`
+default) the chart injects the `FS_UPLOAD_ROOT` environment variable so staged
+multipart uploads land on the desired path. Enabling `.fsBackend.uploads`
+provisions a second PersistentVolumeClaim (or reuses the configured
+`.fsBackend.uploads.existingClaim`) mounted at the chosen location to host the
+staging directory.
 
 Additional POSIX permission settings (such as `FS_FILE_MODE`) should be added to
 `.env.config`. Grant the pod access to the PersistentVolume by enabling `.rbac`

--- a/deploy/charts/gha-cache-server/README.md
+++ b/deploy/charts/gha-cache-server/README.md
@@ -85,15 +85,15 @@ fsBackend:
   uploads:
     enabled: true
     mountPath: /var/lib/gha-cache-uploads
-    size: 50Gi
+    emptyDir:
+      medium: Memory
 ```
 
 When `uploadRoot` is set (explicitly or via the `.fsBackend.uploads.mountPath`
 default) the chart injects the `FS_UPLOAD_ROOT` environment variable so staged
-multipart uploads land on the desired path. Enabling `.fsBackend.uploads`
-provisions a second PersistentVolumeClaim (or reuses the configured
-`.fsBackend.uploads.existingClaim`) mounted at the chosen location to host the
-staging directory.
+multipart uploads land on the desired path. Enabling `.fsBackend.uploads` mounts
+an ephemeral `emptyDir` volume at the configured `mountPath`, keeping temporary
+uploads outside the persistent cache storage.
 
 Additional POSIX permission settings (such as `FS_FILE_MODE`) should be added to
 `.env.config`. Grant the pod access to the PersistentVolume by enabling `.rbac`

--- a/deploy/charts/gha-cache-server/templates/deployment.yaml
+++ b/deploy/charts/gha-cache-server/templates/deployment.yaml
@@ -127,13 +127,17 @@ spec:
           {{- end }}
         {{- if .Values.fsBackend.uploads.enabled }}
         - name: uploads
-          {{- if .Values.fsBackend.uploads.existingClaim }}
-          persistentVolumeClaim:
-            claimName: {{ .Values.fsBackend.uploads.existingClaim }}
-          {{- else }}
-          persistentVolumeClaim:
-            claimName: {{ include "gha-cache-server.fullname" . }}-fs-uploads
-          {{- end }}
+          ephemeral:
+            volumeClaimTemplate:
+              metadata:
+                labels:
+                  type: {{ include "gha-cache-server.fullname" . }}-uploads
+              spec:
+                accessModes: {{ .Values.fsBackend.uploads.accessModes }}
+                storageClassName: {{ .Values.fsBackend.uploads.storageClassName|quote }}
+                resources:
+                  requests:
+                    storage: {{ .Values.fsBackend.uploads.size|quote }}
         {{- end }}
       {{- end }}
       {{- with .Values.nodeSelector }}

--- a/deploy/charts/gha-cache-server/templates/deployment.yaml
+++ b/deploy/charts/gha-cache-server/templates/deployment.yaml
@@ -75,9 +75,20 @@ spec:
           envFrom:
             {{- toYaml $envFrom | nindent 12 }}
           {{- end }}
-          {{- with .Values.env.extra }}
+          {{- $uploadRoot := .Values.fsBackend.uploadRoot -}}
+          {{- if and .Values.fsBackend.uploads.enabled (or (eq $uploadRoot nil) (eq $uploadRoot "")) -}}
+          {{- $uploadRoot = .Values.fsBackend.uploads.mountPath -}}
+          {{- end -}}
+          {{- $env := list -}}
+          {{- if and .Values.fsBackend.enabled $uploadRoot -}}
+          {{- $env = append $env (dict "name" "FS_UPLOAD_ROOT" "value" $uploadRoot) -}}
+          {{- end -}}
+          {{- range .Values.env.extra -}}
+          {{- $env = append $env . -}}
+          {{- end -}}
+          {{- if $env }}
           env:
-            {{- toYaml . | nindent 12 }}
+            {{- toYaml $env | nindent 12 }}
           {{- end }}
           {{- with .Values.securityContext }}
           securityContext:
@@ -99,6 +110,10 @@ spec:
           volumeMounts:
             - name: storage
               mountPath: {{ .Values.fsBackend.mountPath }}
+            {{- if .Values.fsBackend.uploads.enabled }}
+            - name: uploads
+              mountPath: {{ .Values.fsBackend.uploads.mountPath }}
+            {{- end }}
           {{- end }}
       {{- if .Values.fsBackend.enabled }}
       volumes:
@@ -110,6 +125,16 @@ spec:
           persistentVolumeClaim:
             claimName: {{ include "gha-cache-server.fullname" . }}-fs
           {{- end }}
+        {{- if .Values.fsBackend.uploads.enabled }}
+        - name: uploads
+          {{- if .Values.fsBackend.uploads.existingClaim }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.fsBackend.uploads.existingClaim }}
+          {{- else }}
+          persistentVolumeClaim:
+            claimName: {{ include "gha-cache-server.fullname" . }}-fs-uploads
+          {{- end }}
+        {{- end }}
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/deploy/charts/gha-cache-server/templates/pvc.yaml
+++ b/deploy/charts/gha-cache-server/templates/pvc.yaml
@@ -17,23 +17,3 @@ spec:
   storageClassName: {{ . }}
   {{- end }}
 {{- end }}
-{{- if and .Values.fsBackend.enabled .Values.fsBackend.uploads.enabled (not .Values.fsBackend.uploads.existingClaim) }}
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: {{ include "gha-cache-server.fullname" . }}-fs-uploads
-  labels:
-    {{- include "gha-cache-server.labels" . | nindent 4 }}
-spec:
-  accessModes:
-    {{- range .Values.fsBackend.uploads.accessModes }}
-    - {{ . }}
-    {{- end }}
-  resources:
-    requests:
-      storage: {{ .Values.fsBackend.uploads.size }}
-  {{- with .Values.fsBackend.uploads.storageClassName }}
-  storageClassName: {{ . }}
-  {{- end }}
-{{- end }}

--- a/deploy/charts/gha-cache-server/templates/pvc.yaml
+++ b/deploy/charts/gha-cache-server/templates/pvc.yaml
@@ -17,3 +17,23 @@ spec:
   storageClassName: {{ . }}
   {{- end }}
 {{- end }}
+{{- if and .Values.fsBackend.enabled .Values.fsBackend.uploads.enabled (not .Values.fsBackend.uploads.existingClaim) }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "gha-cache-server.fullname" . }}-fs-uploads
+  labels:
+    {{- include "gha-cache-server.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    {{- range .Values.fsBackend.uploads.accessModes }}
+    - {{ . }}
+    {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.fsBackend.uploads.size }}
+  {{- with .Values.fsBackend.uploads.storageClassName }}
+  storageClassName: {{ . }}
+  {{- end }}
+{{- end }}

--- a/deploy/charts/gha-cache-server/values.yaml
+++ b/deploy/charts/gha-cache-server/values.yaml
@@ -86,12 +86,24 @@ env:
 fsBackend:
   enabled: false
   mountPath: /var/lib/gha-cache-server
+  # Optional staging directory exposed via the FS_UPLOAD_ROOT environment variable.
+  # Defaults to .fsBackend.uploads.mountPath when the uploads volume is enabled.
+  uploadRoot: ""
   # When set, the deployment uses the referenced PersistentVolumeClaim instead of creating one.
   existingClaim: ""
   storageClassName: ""
   accessModes:
     - ReadWriteOnce
   size: 100Gi
+  uploads:
+    enabled: false
+    mountPath: /var/lib/gha-cache-uploads
+    # When set, the deployment uses the referenced PersistentVolumeClaim instead of creating one.
+    existingClaim: ""
+    storageClassName: ""
+    accessModes:
+      - ReadWriteOnce
+    size: 50Gi
 
 nodeSelector: {}
 

--- a/deploy/charts/gha-cache-server/values.yaml
+++ b/deploy/charts/gha-cache-server/values.yaml
@@ -96,14 +96,11 @@ fsBackend:
     - ReadWriteOnce
   size: 100Gi
   uploads:
-    enabled: false
+    enabled: true
     mountPath: /var/lib/gha-cache-uploads
-    # When set, the deployment uses the referenced PersistentVolumeClaim instead of creating one.
-    existingClaim: ""
+    accessModes: [ "ReadWriteOnce" ]
     storageClassName: ""
-    accessModes:
-      - ReadWriteOnce
-    size: 50Gi
+    size: 20Gi
 
 nodeSelector: {}
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,9 +20,11 @@ The server supports pluggable blob storage. Select the implementation via the
 
 When `BLOB_STORE=fs` the process reads additional options:
 
-* `FS_ROOT` – absolute or relative path used as the storage root. Multipart
-  uploads are written to a temporary directory under this root and atomically
-  renamed into place when completed.
+* `FS_ROOT` – absolute or relative path used as the storage root. Completed
+  uploads are atomically renamed into place below this directory.
+* `FS_UPLOAD_ROOT` – optional directory used to stage multipart uploads before
+  they are finalized. When unset the server creates a sibling directory next to
+  `FS_ROOT`.
 * `FS_FILE_MODE` – optional octal file permission (for example `0640` or
   `0o640`). When set, the mode is applied to uploaded artifacts.
 * `FS_DIR_MODE` – optional octal directory permission. When provided it is

--- a/docs/container-image.md
+++ b/docs/container-image.md
@@ -20,6 +20,8 @@ sensible defaults to help local development:
 - `FS_ROOT` – storage path used by the filesystem backend. A persistent volume is
   declared for `/var/lib/gha-cache-server` so that `BLOB_STORE=fs` survives
   container restarts.
+- `FS_UPLOAD_ROOT` – optional staging directory for multipart uploads. Mount an
+  additional volume when the staging area should live on persistent storage.
 - `DATABASE_URL` – connection string for the SQL database. The default assumes a
   Postgres server named `postgres` inside the same Docker Compose project.
 
@@ -50,9 +52,12 @@ services:
     environment:
       BLOB_STORE: fs
       FS_ROOT: /var/lib/gha-cache-server
+      FS_UPLOAD_ROOT: /var/lib/gha-cache-uploads
     volumes:
       - gha-cache-data:/var/lib/gha-cache-server
+      - gha-cache-uploads:/var/lib/gha-cache-uploads
 
 volumes:
   gha-cache-data:
+  gha-cache-uploads:
 ```

--- a/packaging/config/env
+++ b/packaging/config/env
@@ -28,6 +28,7 @@ BLOB_STORE=fs
 
 # Filesystem backend configuration.
 #FS_ROOT=/var/lib/gha-cache-server/blobs
+#FS_UPLOAD_ROOT=/var/lib/gha-cache-uploads
 #FS_FILE_MODE=0640
 #FS_DIR_MODE=0750
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -35,6 +35,7 @@ pub struct S3Config {
 #[derive(Clone)]
 pub struct FsConfig {
     pub root: PathBuf,
+    pub uploads_root: Option<PathBuf>,
     pub file_mode: Option<u32>,
     pub dir_mode: Option<u32>,
 }
@@ -151,8 +152,10 @@ impl Config {
             let root = std::env::var("FS_ROOT")
                 .context("FS_ROOT is required when BLOB_STORE=fs")?
                 .into();
+            let uploads_root = std::env::var("FS_UPLOAD_ROOT").ok().map(Into::into);
             Some(FsConfig {
                 root,
+                uploads_root,
                 file_mode: parse_mode("FS_FILE_MODE")?,
                 dir_mode: parse_mode("FS_DIR_MODE")?,
             })

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,7 +95,15 @@ async fn main() -> anyhow::Result<()> {
                 .fs
                 .as_ref()
                 .context("missing filesystem configuration for selected backend")?;
-            Arc::new(FsStore::new(fs_cfg.root.clone(), fs_cfg.file_mode, fs_cfg.dir_mode).await?)
+            Arc::new(
+                FsStore::new(
+                    fs_cfg.root.clone(),
+                    fs_cfg.uploads_root.clone(),
+                    fs_cfg.file_mode,
+                    fs_cfg.dir_mode,
+                )
+                .await?,
+            )
         }
         BlobStoreSelector::Gcs => {
             let gcs_cfg = cfg

--- a/tests/cleanup.rs
+++ b/tests/cleanup.rs
@@ -79,7 +79,7 @@ async fn cleanup_removes_expired_entries_and_files() {
     let pool = setup_pool().await;
     let temp_dir = TempDir::new().expect("temp dir");
     let store = Arc::new(
-        FsStore::new(temp_dir.path().to_path_buf(), None, None)
+        FsStore::new(temp_dir.path().to_path_buf(), None, None, None)
             .await
             .expect("create store"),
     );
@@ -127,7 +127,7 @@ async fn cleanup_enforces_size_limit() {
     let pool = setup_pool().await;
     let temp_dir = TempDir::new().expect("temp dir");
     let store = Arc::new(
-        FsStore::new(temp_dir.path().to_path_buf(), None, None)
+        FsStore::new(temp_dir.path().to_path_buf(), None, None, None)
             .await
             .expect("create store"),
     );


### PR DESCRIPTION
## Summary
- stage filesystem multipart uploads in a temporary directory outside the cache root before moving finalized artifacts
- add a `delete-all-caches` CLI subcommand that purges stored blobs and metadata using shared cleanup helpers
- clear any remaining upload bookkeeping after purging to leave the database clean

## Testing
- cargo fmt --all
- cargo clippy --fix --allow-dirty --allow-staged --all-targets --all-features
- cargo test --all-targets --all-features

------
https://chatgpt.com/codex/tasks/task_e_68d80b3367bc8333be27dea5b53e4a44