### PR TITLE
fix: escape offset column in upload parts migrations

### DIFF
--- a/migrations/mysql/20250922_000001_add_upload_parts.sql
+++ b/migrations/mysql/20250922_000001_add_upload_parts.sql
@@ -2,7 +2,7 @@ CREATE TABLE IF NOT EXISTS cache_upload_parts (
     upload_id VARCHAR(255) NOT NULL,
     part_index INT NOT NULL,
     part_number INT NOT NULL,
-    offset BIGINT NULL,
+    `offset` BIGINT NULL,
     size BIGINT NOT NULL,
     etag TEXT NULL,
     state VARCHAR(32) NOT NULL CHECK (state IN ('pending','completed')),

--- a/migrations/postgres/20250922_000001_add_upload_parts.sql
+++ b/migrations/postgres/20250922_000001_add_upload_parts.sql
@@ -2,7 +2,7 @@ CREATE TABLE IF NOT EXISTS cache_upload_parts (
     upload_id TEXT NOT NULL,
     part_index INTEGER NOT NULL,
     part_number INTEGER NOT NULL,
-    offset BIGINT,
+    "offset" BIGINT,
     size BIGINT NOT NULL,
     etag TEXT,
     state TEXT NOT NULL CHECK (state IN ('pending','completed')),

--- a/migrations/sqlite/20250922_000001_add_upload_parts.sql
+++ b/migrations/sqlite/20250922_000001_add_upload_parts.sql
@@ -2,7 +2,7 @@ CREATE TABLE IF NOT EXISTS cache_upload_parts (
     upload_id TEXT NOT NULL,
     part_index INTEGER NOT NULL,
     part_number INTEGER NOT NULL,
-    offset BIGINT,
+    "offset" BIGINT,
     size BIGINT NOT NULL,
     etag TEXT,
     state TEXT NOT NULL CHECK (state IN ('pending','completed')),


### PR DESCRIPTION
## Summary
- quote the offset column in the PostgreSQL and SQLite upload parts migrations
- escape the offset column name in the MySQL upload parts migration

## Testing
- not run (not required)

------
https://chatgpt.com/codex/tasks/task_e_68d9488c63ac8333abd44a5b6db4edb2