### PR TITLE
feat: coordinate cache finalization across upload parts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1440,6 +1440,7 @@ dependencies = [
  "hyper 1.7.0",
  "hyper-rustls 0.27.7",
  "hyper-util",
+ "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "prost 0.13.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ http-body-util = { version = "0.1" }
 hyper = { version = "1", features = ["http1", "server"] }
 hyper-rustls = { version = "0.27.7", default-features = false, features = ["aws-lc-rs", "http1", "native-tokio", "tls12"] }
 hyper-util = { version = "0.1.6", features = ["client", "client-legacy", "http1", "tokio"] }
+once_cell = { version = "1" }
 percent-encoding = { version = "2" }
 pin-project-lite = { version = "0.2" }
 prost = { version = "0.13" }

--- a/migrations/mysql/20250923_000001_add_finalize_tracking.sql
+++ b/migrations/mysql/20250923_000001_add_finalize_tracking.sql
@@ -1,0 +1,8 @@
+ALTER TABLE cache_uploads
+    ADD COLUMN active_part_count BIGINT NOT NULL DEFAULT 0,
+    ADD COLUMN pending_finalize BOOLEAN NOT NULL DEFAULT FALSE;
+
+UPDATE cache_uploads SET state = 'completed' WHERE state = 'committed';
+
+ALTER TABLE cache_uploads
+    MODIFY COLUMN state ENUM('reserved','ready','uploading','finalizing','completed','committed','aborted') NOT NULL;

--- a/migrations/postgres/20250923_000001_add_finalize_tracking.sql
+++ b/migrations/postgres/20250923_000001_add_finalize_tracking.sql
@@ -1,0 +1,9 @@
+ALTER TABLE cache_uploads
+    ADD COLUMN active_part_count INTEGER NOT NULL DEFAULT 0,
+    ADD COLUMN pending_finalize BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE cache_uploads
+    DROP CONSTRAINT IF EXISTS cache_uploads_state_check,
+    ADD CONSTRAINT cache_uploads_state_check CHECK (state IN ('reserved','ready','uploading','finalizing','completed','committed','aborted'));
+
+UPDATE cache_uploads SET state = 'completed' WHERE state = 'committed';

--- a/migrations/sqlite/20250923_000001_add_finalize_tracking.sql
+++ b/migrations/sqlite/20250923_000001_add_finalize_tracking.sql
@@ -1,0 +1,38 @@
+CREATE TABLE cache_uploads_new (
+    id TEXT PRIMARY KEY,
+    entry_id TEXT,
+    upload_id TEXT NOT NULL UNIQUE,
+    parts_json TEXT NOT NULL DEFAULT '[]',
+    state TEXT NOT NULL CHECK (state IN ('reserved','ready','uploading','finalizing','completed','committed','aborted')),
+    active_part_count INTEGER NOT NULL DEFAULT 0,
+    pending_finalize INTEGER NOT NULL DEFAULT 0,
+    created_at BIGINT NOT NULL DEFAULT (strftime('%s','now')),
+    updated_at BIGINT NOT NULL DEFAULT (strftime('%s','now')),
+    FOREIGN KEY (entry_id) REFERENCES cache_entries(id) ON DELETE CASCADE
+);
+
+INSERT INTO cache_uploads_new (
+    id,
+    entry_id,
+    upload_id,
+    parts_json,
+    state,
+    active_part_count,
+    pending_finalize,
+    created_at,
+    updated_at
+)
+SELECT
+    id,
+    entry_id,
+    upload_id,
+    parts_json,
+    CASE state WHEN 'committed' THEN 'completed' ELSE state END,
+    0,
+    0,
+    created_at,
+    updated_at
+FROM cache_uploads;
+
+DROP TABLE cache_uploads;
+ALTER TABLE cache_uploads_new RENAME TO cache_uploads;

--- a/src/api/twirp.rs
+++ b/src/api/twirp.rs
@@ -315,6 +315,23 @@ pub async fn finalize_cache_entry_upload(
         .await?;
     let upload_id: String = rec.try_get("upload_id")?;
     let storage_key: String = rec.try_get("storage_key")?;
+    let notifier = meta::register_finalize_waiter(&upload_id);
+    if let Err(err) =
+        meta::set_pending_finalize(&st.pool, st.database_driver, &upload_id, true).await
+    {
+        meta::clear_finalize_waiter(&upload_id);
+        return Err(err.into());
+    }
+
+    if let Err(err) =
+        meta::wait_for_no_active_parts(&st.pool, st.database_driver, &upload_id, notifier.clone())
+            .await
+    {
+        let _ = meta::set_pending_finalize(&st.pool, st.database_driver, &upload_id, false).await;
+        meta::clear_finalize_waiter(&upload_id);
+        return Err(err.into());
+    }
+
     let reserved = meta::transition_upload_state(
         &st.pool,
         st.database_driver,
@@ -324,6 +341,8 @@ pub async fn finalize_cache_entry_upload(
     )
     .await?;
     if !reserved {
+        let _ = meta::set_pending_finalize(&st.pool, st.database_driver, &upload_id, false).await;
+        meta::clear_finalize_waiter(&upload_id);
         return Err(ApiError::BadRequest(
             "upload is still receiving parts".into(),
         ));
@@ -339,6 +358,8 @@ pub async fn finalize_cache_entry_upload(
             "ready",
         )
         .await;
+        let _ = meta::set_pending_finalize(&st.pool, st.database_driver, &upload_id, false).await;
+        meta::clear_finalize_waiter(&upload_id);
         return Err(err);
     }
 
@@ -364,6 +385,9 @@ pub async fn finalize_cache_entry_upload(
             )
             .await?;
             if !finalized {
+                let _ = meta::set_pending_finalize(&st.pool, st.database_driver, &upload_id, false)
+                    .await;
+                meta::clear_finalize_waiter(&upload_id);
                 return Err(ApiError::Internal(
                     "failed to record completed upload state".into(),
                 ));
@@ -378,9 +402,15 @@ pub async fn finalize_cache_entry_upload(
                 "ready",
             )
             .await;
+            let _ =
+                meta::set_pending_finalize(&st.pool, st.database_driver, &upload_id, false).await;
+            meta::clear_finalize_waiter(&upload_id);
             return Err(ApiError::S3(format!("{err}")));
         }
     }
+
+    let _ = meta::set_pending_finalize(&st.pool, st.database_driver, &upload_id, false).await;
+    meta::clear_finalize_waiter(&upload_id);
 
     Ok(TwirpResponse::new(
         TwirpFinalizeResp {


### PR DESCRIPTION
## Summary
- add database columns and updated constraints to track active multipart uploads and pending finalization
- expose meta helpers to manage active part counters and wake finalizers when uploads finish
- block new chunks during finalization, wait for in-flight parts before completing uploads, and cover the scenario in tests

## Testing
- cargo clippy --fix --allow-dirty --allow-staged --all-targets --all-features
- cargo test --all-targets --all-features

------
https://chatgpt.com/codex/tasks/task_e_68d9584f652483339a42b3b46a01608a