### PR TITLE
fix: rename cache upload parts offset column

### DIFF
--- a/migrations/mysql/20250922_000001_add_upload_parts.sql
+++ b/migrations/mysql/20250922_000001_add_upload_parts.sql
@@ -2,7 +2,7 @@ CREATE TABLE IF NOT EXISTS cache_upload_parts (
     upload_id VARCHAR(255) NOT NULL,
     part_index INT NOT NULL,
     part_number INT NOT NULL,
-    `offset` BIGINT NULL,
+    part_offset BIGINT NULL,
     size BIGINT NOT NULL,
     etag TEXT NULL,
     state VARCHAR(32) NOT NULL CHECK (state IN ('pending','completed')),

--- a/migrations/postgres/20250922_000001_add_upload_parts.sql
+++ b/migrations/postgres/20250922_000001_add_upload_parts.sql
@@ -2,7 +2,7 @@ CREATE TABLE IF NOT EXISTS cache_upload_parts (
     upload_id TEXT NOT NULL,
     part_index INTEGER NOT NULL,
     part_number INTEGER NOT NULL,
-    "offset" BIGINT,
+    part_offset BIGINT,
     size BIGINT NOT NULL,
     etag TEXT,
     state TEXT NOT NULL CHECK (state IN ('pending','completed')),

--- a/migrations/sqlite/20250922_000001_add_upload_parts.sql
+++ b/migrations/sqlite/20250922_000001_add_upload_parts.sql
@@ -2,7 +2,7 @@ CREATE TABLE IF NOT EXISTS cache_upload_parts (
     upload_id TEXT NOT NULL,
     part_index INTEGER NOT NULL,
     part_number INTEGER NOT NULL,
-    "offset" BIGINT,
+    part_offset BIGINT,
     size BIGINT NOT NULL,
     etag TEXT,
     state TEXT NOT NULL CHECK (state IN ('pending','completed')),


### PR DESCRIPTION
## Summary
- rename the `offset` column in the cache_upload_parts migrations to `part_offset`
- update metadata queries to read and write the renamed column

## Testing
- cargo fmt --all
- cargo clippy --fix --allow-dirty --allow-staged --all-targets --all-features
- cargo clippy --all-targets --all-features
- cargo test --all-targets --all-features

------
https://chatgpt.com/codex/tasks/task_e_68d9321b76bc83339188aa4654696123