### PR TITLE
feat(storage): release fs page cache after transfers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1440,6 +1440,7 @@ dependencies = [
  "hyper 1.7.0",
  "hyper-rustls 0.27.7",
  "hyper-util",
+ "libc",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ http-body-util = { version = "0.1" }
 hyper = { version = "1", features = ["http1", "server"] }
 hyper-rustls = { version = "0.27.7", default-features = false, features = ["aws-lc-rs", "http1", "native-tokio", "tls12"] }
 hyper-util = { version = "0.1.6", features = ["client", "client-legacy", "http1", "tokio"] }
+libc = { version = "0.2" }
 once_cell = { version = "1" }
 percent-encoding = { version = "2" }
 pin-project-lite = { version = "0.2" }


### PR DESCRIPTION
## Summary
- add a libc-based helper that drops file page cache via `posix_fadvise` on Unix
- invoke page cache eviction after multipart writes and when download streams are dropped
- add an fs store integration test that verifies RSS returns to baseline after a large download completes

## Testing
- cargo fmt --all
- cargo clippy --fix --allow-dirty --allow-staged --all-targets --all-features
- cargo test --all-targets --all-features

------
https://chatgpt.com/codex/tasks/task_e_68daa3320c908333848dcd4c9482111e